### PR TITLE
fix: fallback to re if re2 not present

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -193,7 +193,6 @@ repos:
         # Needed for pylint import checks.
         # See https://stackoverflow.com/a/61238571/18829.
         additional_dependencies:
-          - pyre2
           - ruamel.yaml
         args: [--messages-only]
   - repo: https://github.com/PyCQA/bandit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -344,5 +344,6 @@ ci:
   autoupdate_schedule: monthly
   skip:
     - markdown-link-check
+    - poetry-lock
     - reliabot
     - reliabot-pre-commit-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -342,3 +342,7 @@ repos:
         types: [python]
 ci:
   autoupdate_schedule: monthly
+  skip:
+    - markdown-link-check
+    - reliabot
+    - reliabot-pre-commit-files

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,6 +8,10 @@
   args: [--update]
   pass_filenames: false
   language: python
+  additional_dependencies:
+    - ruamel.yaml
+    # If possible, add pyre2-updated or pyre2 as additional_dependencies
+    # in your .pre-commit-config.yaml to get RE2 support (libre2 required)
   stages: [manual, pre-commit, pre-merge-commit, pre-push]
   exclude_types: [binary, directory, symlink]
   # prettier-ignore

--- a/reliabot/reliabot.py
+++ b/reliabot/reliabot.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import warnings
 from collections import defaultdict
 from enum import IntEnum
 from io import SEEK_SET
@@ -39,11 +40,20 @@ from typing import Iterator
 from typing import TextIO
 from typing import Union
 
-import re2 as re  # Avoids terrible consequences for pathological RE matching.
 from ruamel.yaml import YAML  # ruamel.yaml preserves comments, PyYAML doesn't.
 from ruamel.yaml.comments import CommentedMap
 from ruamel.yaml.comments import CommentedSeq
 from ruamel.yaml.parser import ParserError
+
+try:
+    # Avoids terrible consequences for pathological RE matching.
+    import re2 as re
+except ImportError:
+    import re
+
+    warnings.warn("Cannot import re2, falling back to re", RuntimeWarning)
+else:
+    re.set_fallback_notification(re.FALLBACK_WARNING)
 
 
 class Err(IntEnum):

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,6 @@ warn_unused_ignores = true
 packages = find:
 install_requires =
     ruamel.yaml>=0.17
-    pyre2>=0.3
 python_requires = >=3.8
 
 [options.packages.find]


### PR DESCRIPTION
Some environments may not be able to install `pyre2` or `pyre2-updated`.
Reliabot should use `re` in those cases.