### PR TITLE
Fixes for many problems updating configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 *.swp
 .idea/
+/.run/
 ci/.bootstrap
 
 # Byte-compiled / optimized / DLL files

--- a/reliabot/reliabot.py
+++ b/reliabot/reliabot.py
@@ -231,6 +231,11 @@ def main(optargv: Optional[list[str]] = None) -> int:  # noqa: MC0001
     :param optargv: command name and arguments.
     :returns: exit code – 0 for success, 1–9 for different failures.
 
+    >>> sys.argv = ["--"]
+    >>> main()
+    Traceback (most recent call last):
+    ...
+    SystemExit: 2
     >>> main(["reliabot.py", OPT_UPDATE]) # Requires updated dependabot config,
     0
     >>> main(["reliabot.py", OPT_UPDATE_PRE_COMMIT]) # ..and pre-commit config.

--- a/reliabot/reliabot.py
+++ b/reliabot/reliabot.py
@@ -236,9 +236,9 @@ def main(optargv: Optional[list[str]] = None) -> int:  # noqa: MC0001
     Traceback (most recent call last):
     ...
     SystemExit: 2
-    >>> main(["reliabot.py", OPT_UPDATE]) # Requires updated dependabot config,
+    >>> main(["reliabot.py", OPT_UPDATE]) # Updated dependabot config required,
     0
-    >>> main(["reliabot.py", OPT_UPDATE_PRE_COMMIT]) # ..and pre-commit config.
+    >>> main(["reliabot.py", OPT_UPDATE_PRE_COMMIT]) # also pre-commit config.
     0
     >>> test_dir = "testdir/github/"
     >>> test_conf = f"{test_dir}/.github/{fsdecode(DEPENDABOT_CONFIG)}"
@@ -541,7 +541,7 @@ def find_ecosystems(
     >>> config_dir = join(TESTDIR, b"configured")
     >>> dont_ignore = lambda dir_path: False
     >>> find_ecosystems(config_dir, dont_ignore)   # doctest: +ELLIPSIS
-    defaultdict(<class 'set'>, {'/': {'github-actions'}, '/bundler':...
+    defaultdict(<class 'set'>, {'/': {'github-actions'}, '/bundler':...)
     """
     ecosystems = defaultdict(set)
     workflows = GITHUB_WORKFLOWS.decode("utf-8")
@@ -859,7 +859,7 @@ def config_emitter(emitter: YAML, settings: dict[str, Any]) -> dict[str, int]:
     r"""Apply reliabot YAML format settings to a YAML parser/emitter.
 
     :param emitter: A ruamel.yaml parser/emitter.
-    :param settings: Emitter settings (indentation, etcetera.
+    :param settings: Emitter settings (indentation, etcetera.)
     :returns: dict with indentation settings (mapping, offset, sequence).
 
     >>> test_emitter = YAML(pure=PURE)

--- a/reliabot/reliabot.py
+++ b/reliabot/reliabot.py
@@ -829,7 +829,8 @@ def update_pre_commit_file_patterns(config_file: TextIO) -> bool:
     :raises AttributeError: if file is empty.
     :raises KeyError: if list lacks 'id', map lacks 'repos', 'repo' or 'hooks'.
 
-    >>> _ = re.compile(ECOSYSTEM_RE_FILES)
+    >>> import re as pcre  # Python PCRE needed for (?x) in YAML configs.
+    >>> _ = pcre.compile(ECOSYSTEM_RE_FILES)
     >>> ECOSYSTEM_FILE_ACTIONS in ECOSYSTEM_RE_FILES
     True
     >>> "?P<" not in ECOSYSTEM_RE_FILES  # Ensure it doesn't have named groups.


### PR DESCRIPTION
- test: no argument passed to main
- fix: PyCharm warnings
- fix: correctly remove configs and truncate
- fix: don't use re2 for config file patterns
- fix: refactor to use Exclusions for kept folders too
  This unifies the matching logic and fixes a bug where kept folders
  had to be specified with a leading / - unlike ignored folders,
  and the documentation, which specified that leading / was ignored.