### PR TITLE
docs: CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,15 +5,17 @@
 There are _many_ ways to contribute – one of the best is just using Reliabot
 for your projects – and no contribution is too small or too large.
 
-- [Ask a question][1] about using Reliabot.
-- [Open an issue][2] about a problem, or for a way to improve Reliabot.
-- [Improve the docs][3] by fixing typos and broken links, or writing a HowTo.
-- [Write code][4] to add a feature or support for a distribution packager.
+- [Ask a question](#asking-a-question) about using Reliabot.
+- [Open an issue][1] about a problem, or for a way to improve Reliabot.
+- [Improve the docs](#improving-the-documentation) by fixing typos and broken
+  links, or writing a HowTo.
+- [Write code](#contributing-code-and-bug-fixes) to add a feature or support
+  for a distribution packager.
 
-See the [Table of contents][5] for different ways to help and details about how
-to contribute to Reliabot. _Please read the relevant section before
-contributing_. This makes the process easier and improves the experience for
-everyone.
+See the [Table of contents](#table-of-contents) for different ways to help and
+details about how to contribute to Reliabot. _Please read the relevant section
+before contributing_. This makes the process easier and improves the experience
+for everyone.
 
 👀 Looking forward to your contributions 🎉
 
@@ -52,17 +54,17 @@ everyone.
 
 ## Asking a question
 
-> 💡 If you have a Reliabot question, take a look at the [README][6] and its
-> [FAQ][7] to see if it's answered there.
+> 💡 If you have a Reliabot question, take a look at the [README][2] and its
+> [FAQ][3] to see if it's answered there.
 
-Before asking a question, search for [existing issues][8] that are similar. If
+Before asking a question, search for [existing issues][4] that are similar. If
 you find a relevant issue but still need clarification, ask your question in
 that issue. A few internet search queries may also turn up an answer quickly.
 
 If you don't find an answer or an existing issue, follow these steps to ask
 your question:
 
-- [Create a new issue][9], labeling it as a 🟣 **question**.
+- [Create a new issue][5], labeling it as a 🟣 **question**.
 - Provide as much context as you can for your question.
   - Reliabot version
   - Whether you're running Reliabot with pre-commit or on the command line
@@ -81,15 +83,15 @@ counter-examples, and describe the problem in detail. Completing the following
 steps in advance helps to fix any potential bug as fast as possible.
 
 - To see if other users have experienced (and perhaps already solved) your
-  problem, search the [bug tracker][10] for similar issues or error messages.
+  problem, search the [bug tracker][6] for similar issues or error messages.
 - Searching the internet (especially Stack Overflow) can help you find any
   users of other tools, or in other forums, who have run into a similar
   problem.
 - Make sure you are using the latest Reliabot version.
 - Confirm that your problem is really a bug and not an error on your part, such
   as using Reliabot with unsupported environments or versions. Reading the
-  [documentation][6] can help. If you need help, consider just
-  [asking a question][1] first.
+  [documentation][2] can help. If you need help, consider just
+  [asking a question](#asking-a-question) first.
 - Collect information about the problem:
   - Specific Reliabot command line and context.
   - Reliabot output, including error messages, warnings, and stack traces.
@@ -106,14 +108,14 @@ steps in advance helps to fix any potential bug as fast as possible.
 
 > ⚠️Don't report security related issues or vulnerabilities, or include
 > sensitive information in reports on the issue tracker, or elsewhere in
-> public. Instead, [open a draft security advisory][11] and provide the
-> vulnerability information there. See the [Reliabot security policy][12] for
+> public. Instead, [open a draft security advisory][7] and provide the
+> vulnerability information there. See the [Reliabot security policy][8] for
 > more details.
 
-The Reliabot project uses [GitHub issues][8] for tracking bugs. If you found a
+The Reliabot project uses [GitHub issues][4] for tracking bugs. If you found a
 problem using Reliabot:
 
-- [Create an issue using the problem template][13]. It may not be clear yet
+- [Create an issue using the problem template][9]. It may not be clear yet
   whether it's a bug, so please don't label the issue.
 - Describe the behavior you expect and the differences in the actual behavior.
 - Please provide as much context as possible and describe the *reproduction
@@ -141,8 +143,9 @@ Once you have created the issue:
   mark the issue as **help wanted** or **invalid**. Until someone can reproduce
   the problem, they won't try to fix it.
 - Once they can reproduce the problem, they'll assign it to someone to
-  [implement a fix][14]. If you indicated interest in working on a fix, or that
-  you already have a proposed fix, they may assign it to you.
+  [implement a fix](#becoming-a-contributor). If you indicate interest in
+  working on a fix, or that you already have a proposed fix, they may assign it
+  to you.
 
 ## Suggesting enhancements
 
@@ -154,8 +157,8 @@ suggestion and how it relates to other approaches.
 ### Before suggesting an enhancement
 
 - Make sure you are using the latest Reliabot version.
-- Read the [documentation][6] to see if Reliabot can already do what you want.
-- [Search the issues][8] to see if somebody already suggested this enhancement.
+- Read the [documentation][2] to see if Reliabot can already do what you want.
+- [Search the issues][4] to see if somebody already suggested this enhancement.
   If so, add a comment to that existing issue instead of opening a new one.
 - Find out whether your idea fits with the scope and aims of the project. It's
   up to you to make a strong case for the merits of this feature. Keep in mind
@@ -163,10 +166,10 @@ suggestion and how it relates to other approaches.
 
 ### Writing a good enhancement suggestion
 
-The Reliabot project tracks [enhancement suggestions][15] with GitHub issues.
+The Reliabot project tracks [enhancement suggestions][10] with GitHub issues.
 To suggest an enhancement for Reliabot:
 
-- [Create an issue using the enhancement template][16], labeling it as an 🔵
+- [Create an issue using the enhancement template][11], labeling it as an 🔵
   **enhancement**.
 - Use a **clear and descriptive title** to identify the enhancement.
 - Describe any problem the enhancement would solve, and explain how.
@@ -181,11 +184,11 @@ To suggest an enhancement for Reliabot:
 > #### Legal Notice
 >
 > By contributing code or documentation to this project, you are certifying,
-> per the [Developer Certificate of Origin][17] version 1.1 or later, that you
+> per the [Developer Certificate of Origin][12] version 1.1 or later, that you
 > have the necessary rights to the content you contribute, and that they allow
-> distribution under the [Reliabot project license][18],
+> distribution under the [Reliabot project license][13],
 >
-> You do this by ["signing off" your commits][19]. "Signing off" isn't
+> You do this by ["signing off" your commits][14]. "Signing off" isn't
 > cryptographic, it's just a line like "Signed-off-by: your name
 > <your.email@example.org>" at the end of a commit message. You can add it
 > manually when squash merging a PR, or by giving the `-s` or `--signoff`
@@ -194,15 +197,15 @@ To suggest an enhancement for Reliabot:
 ### First contributions
 
 Unsure where to start contributing? Start by looking at Reliabot issues labeled
-[**good first issue**][20] or [**help wanted**][21].
+[**good first issue**][15] or [**help wanted**][16].
 
 - **good first issue** – should only require a few lines of code and a test.
 - **help wanted** – more complex, requiring code design and Python experience.
 
 ### Pre-commit setup
 
-Reliabot uses [pre-commit][22] to perform style checks and fixes. Whether you
-are contributing code or documentation, you should [install pre-commit][23] on
+Reliabot uses [pre-commit][17] to perform style checks and fixes. Whether you
+are contributing code or documentation, you should [install pre-commit][18] on
 your system, and then enable it for your local copy of the Reliabot repository:
 
 ```console
@@ -212,7 +215,7 @@ pre-commit installed at .git/hooks/pre-commit
 
 If you don't (or can't) install pre-commit on your system (say, if you're using
 the GitHub file editor in the web UI to fix a small typo), once you create a
-PR, the [pre-commit.ci][24] service runs the pre-commit checks for you and
+PR, the [pre-commit.ci][19] service runs the pre-commit checks for you and
 pushes fixes to your PRs for many style / formatting issues. Run `git pull` on
 your PR branch after the **pre-commit.ci - pr** checks are no longer pending,
 and show either success or failure.
@@ -226,7 +229,7 @@ and show either success or failure.
 The documentation for Reliabot currently consists of a number of Markdown files
 in standard locations (README.md, CONTRIBUTING.md, SECURITY.md).
 
-There is configuration and a Makefile for using [Vale][25] for checking prose
+There is configuration and a Makefile for using [Vale][20] for checking prose
 style and suggest improvements to the documentation, as well as text in the
 GitHub issue templates. There is no CI integration for Vale, you have to
 install it yourself:
@@ -239,47 +242,48 @@ Once you have installed Vale, you can run it with `make`.
 
 ## Style guides
 
-[Pre-commit checks][26] cover most of the style guides below, and often
-auto-fix style issues, either as local changes in your copy of the Reliabot
-repository, or as commits that pre-commit.ci adds to your PR.
+[Pre-commit checks](#pre-commit-setup) cover most of the style guides below,
+and often auto-fix style issues, either as local changes in your copy of the
+Reliabot repository, or as commits that pre-commit.ci adds to your PR.
 
 ### Commit messages
 
 - Limit the first line to 72 or fewer characters.
-- Start the first line with a [conventional commit type][27], like these
+- Start the first line with a [conventional commit type][21], like these
   examples: `feat:` or `ci(pre-commit):`.
-  - _You can use [commitizen][28] or similar tools to help manage this._
+  - _You can use [commitizen][22] or similar tools to help manage this._
 - Use the present tense ("Add feature" not "Added feature").
 - Use the imperative mood ("Move cursor to…" not "Moves cursor to…").
 - Reference issues and pull requests liberally after the first line.
 
 ### Python code
 
-Reliabot code uses [Black][28] style formatting. Pre-commit checks enforce this
+Reliabot code uses [Black][22] style formatting. Pre-commit checks enforce this
 and some PEP code styles.
 
 ### Shell code
 
 Reliabot pre-commit hooks format shell scripts with `shfmt -i 2 -ci`, and lint
-them with [`shellcheck`][22].
+them with [`shellcheck`][17].
 
 ### Markdown documentation
 
 Reliabot documentation uses GitHub Flavored Markdown, following the
-[Markdown style guide][29] implemented by [Executable Books mdformat][30], with
+[Markdown style guide][23] implemented by [Executable Books mdformat][24], with
 some non-default `mdformat` style settings:
 
-- "Consecutive" numbering for [ordered lists][31] for compatibility with the
-  [markdownlint][32] checker, like this:
+- "Consecutive" numbering for [ordered lists][25] for compatibility with the
+  [markdownlint][26] checker, like this:
   ```markdown
   1. first
   2. second
   3. etcetera
   ```
 - Word wrapping at 79 columns.
-- A pre-commit hook based on a Python script from a [decade-old blog post][33]
-  rewrites all [reference links][34] with numeric tags ordered by appearance in
-  the text.
+- A pre-commit hook based on a Python script from a [decade-old blog post][27]
+  rewrites all [reference links][28] with numeric tags ordered by appearance in
+  the text. This doesn't affect inline links like `[shell](#shell-code)`, used
+  for any references to anchors in the same file but not anything else.
 
 While these settings don't minimize Git diffs in line-by-line diff mode, they
 do maximize readability of the Markdown source files, and the
@@ -291,48 +295,42 @@ configuration language tags.
 
 ### Configuration files
 
-Reliabot uses [Prettier][35] to automatically format CFG, INI, JSON, TOML, and
+Reliabot uses [Prettier][29] to automatically format CFG, INI, JSON, TOML, and
 YAML configuration files. The only non-standard setting is to use single quotes
 in preference to double quotes for formats that allow this.
 
 ## Attribution
 
 The **contributing-gen** generator created the initial version of this file.
-[Make your own CONTRIBUTING.md][36] 📝
+[Make your own CONTRIBUTING.md][30] 📝
 
-[1]: #asking-a-question
-[2]: https://github.com/dupuy/reliabot/issues/new
-[3]: #improving-the-documentation
-[4]: #contributing-code-and-bug-fixes
-[5]: #table-of-contents
-[6]: https://github.com/dupuy/reliabot#reliabot--maintain-github-dependabot-configuration
-[7]: https://github.com/dupuy/reliabot#faq
-[8]: https://github.com/dupuy/reliabot/issues?q=is%3Aissue+sort%3Aupdated-desc
-[9]: https://github.com/dupuy/reliabot/issues/new?assignees=&labels=question&projects=&template=question.md&title=Question+about+...
-[10]: https://github.com/dupuy/reliabot/issues?q=label%3Abug
-[11]: https://github.com/dupuy/reliabot/security/advisories/new
-[12]: https://github.com/dupuy/reliabot/security/policy
-[13]: https://github.com/dupuy/reliabot/issues/new?template=problem.md&title=Problem+with+%E2%80%A6
-[14]: #becoming-a-contributor
-[15]: https://github.com/dupuy/reliabot/issues?q=label%3Aenhancement
-[16]: https://github.com/dupuy/reliabot/issues/new?template=enhancement.md&title=Enhancement+to+https://github.com/dupuy/reliabot/issues/new?template=problem.md&title=Problem+with+%E2%80%A6
-[17]: https://developercertificate.org/
-[18]: https://github.com/dupuy/reliabot/blob/main/LICENSE
-[19]: https://stackoverflow.com/a/14044024
-[20]: https://github.com/dupuy/reliabot/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+sort%3Acomments-desc
-[21]: https://github.com/dupuy/reliabot/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22+sort%3Acomments-desc
-[22]: https://pre-commit.com/
-[23]: https://pre-commit.com/#install
-[24]: https://pre-commit.ci
-[25]: https://vale.sh/
-[26]: #pre-commit-setup
-[27]: https://www.conventionalcommits.org/en/v1.0.0/#summary
-[28]: https://commitizen-tools.github.io/commitizen/
-[29]: https://mdformat.readthedocs.io/en/stable/users/style.html
-[30]: https://github.com/executablebooks/mdformat
-[31]: https://mdformat.readthedocs.io/en/stable/users/style.html#ordered-lists
-[32]: https://github.com/markdownlint/markdownlint
-[33]: https://leancrew.com/all-this/2012/09/tidying-markdown-reference-links/
-[34]: https://mdformat.readthedocs.io/en/stable/users/style.html#reference-links
-[35]: https://prettier.io/docs/en/
-[36]: https://github.com/bttger/contributing-gen
+[1]: https://github.com/dupuy/reliabot/issues/new
+[2]: https://github.com/dupuy/reliabot#reliabot--maintain-github-dependabot-configuration
+[3]: https://github.com/dupuy/reliabot#faq
+[4]: https://github.com/dupuy/reliabot/issues?q=is%3Aissue+sort%3Aupdated-desc
+[5]: https://github.com/dupuy/reliabot/issues/new?assignees=&labels=question&projects=&template=question.md&title=Question+about+...
+[6]: https://github.com/dupuy/reliabot/issues?q=label%3Abug
+[7]: https://github.com/dupuy/reliabot/security/advisories/new
+[8]: https://github.com/dupuy/reliabot/security/policy
+[9]: https://github.com/dupuy/reliabot/issues/new?template=problem.md&title=Problem+with+%E2%80%A6
+[10]: https://github.com/dupuy/reliabot/issues?q=label%3Aenhancement
+[11]: https://github.com/dupuy/reliabot/issues/new?template=enhancement.md&title=Enhancement+to+https://github.com/dupuy/reliabot/issues/new?template=problem.md&title=Problem+with+%E2%80%A6
+[12]: https://developercertificate.org/
+[13]: https://github.com/dupuy/reliabot/blob/main/LICENSE
+[14]: https://stackoverflow.com/a/14044024
+[15]: https://github.com/dupuy/reliabot/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+sort%3Acomments-desc
+[16]: https://github.com/dupuy/reliabot/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22+sort%3Acomments-desc
+[17]: https://pre-commit.com/
+[18]: https://pre-commit.com/#install
+[19]: https://pre-commit.ci
+[20]: https://vale.sh/
+[21]: https://www.conventionalcommits.org/en/v1.0.0/#summary
+[22]: https://commitizen-tools.github.io/commitizen/
+[23]: https://mdformat.readthedocs.io/en/stable/users/style.html
+[24]: https://github.com/executablebooks/mdformat
+[25]: https://mdformat.readthedocs.io/en/stable/users/style.html#ordered-lists
+[26]: https://github.com/markdownlint/markdownlint
+[27]: https://leancrew.com/all-this/2012/09/tidying-markdown-reference-links/
+[28]: https://mdformat.readthedocs.io/en/stable/users/style.html#reference-links
+[29]: https://prettier.io/docs/en/
+[30]: https://github.com/bttger/contributing-gen

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,151 @@
-Placeholder for https://github.com/dupuy/reliabot/pull/23
+<!-- omit in toc -->
+# Contributing to reliabot
+
+First off, thanks for taking the time to contribute! ❤️
+
+All types of contributions are encouraged and valued. See the [Table of Contents](#table-of-contents) for different ways to help and details about how this project handles them. Please make sure to read the relevant section before making your contribution. It will make it a lot easier for us maintainers and smooth out the experience for all involved. The community looks forward to your contributions. 🎉
+
+> And if you like the project, but just don't have time to contribute, that's fine. There are other easy ways to support the project and show your appreciation, which we would also be very happy about:
+> - Star the project
+> - Tweet about it
+> - Refer this project in your project's readme
+> - Mention the project at local meetups and tell your friends/colleagues
+
+<!-- omit in toc -->
+## Table of Contents
+
+- [I Have a Question](#i-have-a-question)
+- [I Want To Contribute](#i-want-to-contribute)
+  - [Reporting Bugs](#reporting-bugs)
+  - [Suggesting Enhancements](#suggesting-enhancements)
+  - [Your First Code Contribution](#your-first-code-contribution)
+  - [Improving The Documentation](#improving-the-documentation)
+- [Styleguides](#styleguides)
+  - [Commit Messages](#commit-messages)
+- [Join The Project Team](#join-the-project-team)
+
+
+
+## I Have a Question
+
+> If you want to ask a question, we assume that you have read the available [Documentation](https://github.com/dupuy/reliabot/blob/main/README.md).
+
+Before you ask a question, it is best to search for existing [Issues](https://github.com/dupuy/reliabot/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
+
+If you then still feel the need to ask a question and need clarification, we recommend the following:
+
+- Open an [Issue](https://github.com/dupuy/reliabot/issues/new).
+- Provide as much context as you can about what you're running into.
+- Provide project and platform versions (nodejs, npm, etc), depending on what seems relevant.
+
+We will then take care of the issue as soon as possible.
+
+<!--
+You might want to create a separate issue tag for questions and include it in this description. People should then tag their issues accordingly.
+
+Depending on how large the project is, you may want to outsource the questioning, e.g. to Stack Overflow or Gitter. You may add additional contact and information possibilities:
+- IRC
+- Slack
+- Gitter
+- Stack Overflow tag
+- Blog
+- FAQ
+- Roadmap
+- E-Mail List
+- Forum
+-->
+
+## I Want To Contribute
+
+> ### Legal Notice <!-- omit in toc -->
+> When contributing to this project, you must agree that you have authored 100% of the content, that you have the necessary rights to the content and that the content you contribute may be provided under the project license.
+
+### Reporting Bugs
+
+<!-- omit in toc -->
+#### Before Submitting a Bug Report
+
+A good bug report shouldn't leave others needing to chase you up for more information. Therefore, we ask you to investigate carefully, collect information and describe the issue in detail in your report. Please complete the following steps in advance to help us fix any potential bug as fast as possible.
+
+- Make sure that you are using the latest version.
+- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](https://github.com/dupuy/reliabot/blob/main/README.md). If you are looking for support, you might want to check [this section](#i-have-a-question)).
+- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/dupuy/reliabot/issues?q=label%3Abug).
+- Also make sure to search the internet (including Stack Overflow) to see if users outside of the GitHub community have discussed the issue.
+- Collect information about the bug:
+  - Stack trace (Traceback)
+  - OS, Platform and Version (Windows, Linux, macOS, x86, ARM)
+  - Version of the interpreter, compiler, SDK, runtime environment, package manager, depending on what seems relevant.
+  - Possibly your input and the output
+  - Can you reliably reproduce the issue? And can you also reproduce it with older versions?
+
+<!-- omit in toc -->
+#### How Do I Submit a Good Bug Report?
+
+> You must never report security related issues, vulnerabilities or bugs including sensitive information to the issue tracker, or elsewhere in public. Instead sensitive bugs must be sent by email to <>.
+<!-- You may add a PGP key to allow the messages to be sent encrypted as well. -->
+
+We use GitHub issues to track bugs and errors. If you run into an issue with the project:
+
+- Open an [Issue](https://github.com/dupuy/reliabot/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
+- Explain the behavior you would expect and the actual behavior.
+- Please provide as much context as possible and describe the *reproduction steps* that someone else can follow to recreate the issue on their own. This usually includes your code. For good bug reports you should isolate the problem and create a reduced test case.
+- Provide the information you collected in the previous section.
+
+Once it's filed:
+
+- The project team will label the issue accordingly.
+- A team member will try to reproduce the issue with your provided steps. If there are no reproduction steps or no obvious way to reproduce the issue, the team will ask you for those steps and mark the issue as `needs-repro`. Bugs with the `needs-repro` tag will not be addressed until they are reproduced.
+- If the team is able to reproduce the issue, it will be marked `needs-fix`, as well as possibly other tags (such as `critical`), and the issue will be left to be [implemented by someone](#your-first-code-contribution).
+
+<!-- You might want to create an issue template for bugs and errors that can be used as a guide and that defines the structure of the information to be included. If you do so, reference it here in the description. -->
+
+
+### Suggesting Enhancements
+
+This section guides you through submitting an enhancement suggestion for reliabot, **including completely new features and minor improvements to existing functionality**. Following these guidelines will help maintainers and the community to understand your suggestion and find related suggestions.
+
+<!-- omit in toc -->
+#### Before Submitting an Enhancement
+
+- Make sure that you are using the latest version.
+- Read the [documentation](https://github.com/dupuy/reliabot/blob/main/README.md) carefully and find out if the functionality is already covered, maybe by an individual configuration.
+- Perform a [search](https://github.com/dupuy/reliabot/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
+- Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on/plugin library.
+
+<!-- omit in toc -->
+#### How Do I Submit a Good Enhancement Suggestion?
+
+Enhancement suggestions are tracked as [GitHub issues](https://github.com/dupuy/reliabot/issues).
+
+- Use a **clear and descriptive title** for the issue to identify the suggestion.
+- Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
+- **Describe the current behavior** and **explain which behavior you expected to see instead** and why. At this point you can also tell which alternatives do not work for you.
+- You may want to **include screenshots and animated GIFs** which help you demonstrate the steps or point out the part which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux. <!-- this should only be included if the project has a GUI -->
+- **Explain why this enhancement would be useful** to most reliabot users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
+
+<!-- You might want to create an issue template for enhancement suggestions that can be used as a guide and that defines the structure of the information to be included. If you do so, reference it here in the description. -->
+
+### Your First Code Contribution
+<!-- TODO
+include Setup of env, IDE and typical getting started instructions?
+
+-->
+
+### Improving The Documentation
+<!-- TODO
+Updating, improving and correcting the documentation
+
+-->
+
+## Styleguides
+### Commit Messages
+<!-- TODO
+
+-->
+
+## Join The Project Team
+<!-- TODO -->
+
+<!-- omit in toc -->
+## Attribution
+This guide is based on the **contributing-gen**. [Make your own](https://github.com/bttger/contributing-gen)!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,28 +1,31 @@
-# Contributing to reliabot
+# Contributing to Reliabot
 
-First off, thanks for taking the time to contribute! ❤️
+🙏Thanks in advance for your contributions ❤️
 
-All types of contributions are encouraged and valued. See the
-[Table of Contents][1] for different ways to help and details about how this
-project handles them. Please make sure to read the relevant section before
-making your contribution. It will make it a lot easier for us maintainers and
-smooth out the experience for all involved. The community looks forward to your
-contributions. 🎉
+There are _many_ ways to contribute – one of the best is just using Reliabot
+for your projects. [Open an issue][4] if you have a problem, or if you think of
+a way to improve Reliabot. Fix a typo or broken URL in the docs, or add support
+for a software distribution packager – no contribution is too small or large.
 
-> And if you like the project, but just don't have time to contribute, that's
-> fine. There are other easy ways to support the project and show your
-> appreciation, which we would also be very happy about:
+See the [Table of contents][1] for different ways to help and details about how
+this project handles them. _Please read the relevant section before
+contributing_. This makes it easier for the team and improves the experience
+for everyone.
+
+👀 Looking forward to your contributions 🎉
+
+> If you use or like the project, but don't have time to contribute, that's OK.
+> Here are some easy ways to support Reliabot and show your appreciation.
 >
-> - Star the project
-> - Tweet about it
-> - Refer this project in your project's readme
-> - Mention the project at local meetups and tell your friends/colleagues
+> - Star the Reliabot GitHub project
+> - Refer to Reliabot in your project's README
+> - Mention Reliabot in social media
 
-## Table of Contents
+## Table of contents
 
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=3 --minlevel=2 -->
 
-- [Table of Contents](#table-of-contents)
+- [Table of contents](#table-of-contents)
 - [I Have a Question](#i-have-a-question)
 - [I Want To Contribute](#i-want-to-contribute)
   - [Legal Notice](#legal-notice)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,24 +29,30 @@ everyone.
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=3 --minlevel=2 -->
 
 - [Asking a question](#asking-a-question)
-- [Reporting bugs](#reporting-bugs)
-  - [Before submitting a bug report](#before-submitting-a-bug-report)
-  - [How to submit a good bug report](#how-to-submit-a-good-bug-report)
+- [Reporting problems](#reporting-problems)
+  - [Before submitting a problem report](#before-submitting-a-problem-report)
+  - [How to submit a good problem report](#how-to-submit-a-good-problem-report)
 - [Suggesting enhancements](#suggesting-enhancements)
   - [Before suggesting an enhancement](#before-suggesting-an-enhancement)
-  - [Writing a good enhancement issue](#writing-a-good-enhancement-issue)
+  - [Writing a good enhancement suggestion](#writing-a-good-enhancement-suggestion)
 - [Becoming a contributor](#becoming-a-contributor)
+  - [First contributions](#first-contributions)
+  - [Pre-commit setup](#pre-commit-setup)
   - [Contributing code and bug fixes](#contributing-code-and-bug-fixes)
   - [Improving the documentation](#improving-the-documentation)
 - [Style guides](#style-guides)
   - [Commit messages](#commit-messages)
+  - [Python code](#python-code)
+  - [Shell code](#shell-code)
+  - [Markdown documentation](#markdown-documentation)
+  - [Configuration files](#configuration-files)
 - [Attribution](#attribution)
 
 <!-- mdformat-toc end -->
 
 ## Asking a question
 
-> ℹ️ If you have a Reliabot question, take a look at the [README][6] and its
+> 💡 If you have a Reliabot question, take a look at the [README][6] and its
 > [FAQ][7] to see if it's answered there.
 
 Before asking a question, search for [existing issues][8] that are similar. If
@@ -56,66 +62,69 @@ that issue. A few internet search queries may also turn up an answer quickly.
 If you don't find an answer or an existing issue, follow these steps to ask
 your question:
 
-- [Create a new issue][2], labeling it as a 🟣 **question**.
+- [Create a new issue][9], labeling it as a 🟣 **question**.
 - Provide as much context as you can for your question.
   - Reliabot version
   - Whether you're running Reliabot with pre-commit or on the command line
-  - OS type and CPU architecture, and versions for the OS and Python runtime
+  - Operating System (distribution) and Python versions
 - Explain what you're trying to do, and what you don't understand.
 
 Someone should respond to the issue as soon as possible. Be patient. 🕗😊
 
-## Reporting bugs
+## Reporting problems
 
-### Before submitting a bug report
+### Before submitting a problem report
 
-A good bug report shouldn't force others to contact you for critical missing
-information. Please investigate carefully, find examples and counter-examples,
-and describe the problem in detail. Completing the following steps in advance
-helps to fix any potential bug as fast as possible.
+A good problem report shouldn't force others to contact you for critical
+missing information. Please investigate carefully, find examples and
+counter-examples, and describe the problem in detail. Completing the following
+steps in advance helps to fix any potential bug as fast as possible.
 
-- Make sure you are using the latest Reliabot version.
-- Confirm that your problem is really a bug and not an error on your part, such
-  as using Reliabot with unsupported environments or versions. Reading the
-  [documentation][6] can help. If you need support, consider just
-  [asking a question][1] first.
-- To see if other users have experienced (and perhaps already solved) the same
-  problem as you, search the [bug tracker][9] for similar issues or error
-  messages.
+- To see if other users have experienced (and perhaps already solved) your
+  problem, search the [bug tracker][10] for similar issues or error messages.
 - Searching the internet (especially Stack Overflow) can help you find any
   users of other tools, or in other forums, who have run into a similar
   problem.
-- Collect information about the bug:
+- Make sure you are using the latest Reliabot version.
+- Confirm that your problem is really a bug and not an error on your part, such
+  as using Reliabot with unsupported environments or versions. Reading the
+  [documentation][6] can help. If you need help, consider just
+  [asking a question][1] first.
+- Collect information about the problem:
   - Specific Reliabot command line and context.
-  - All error messages and warnings, including stack traces. Setting
-    `PYTHONWARNINGS=default` in the environment can show extra diagnostics.
-  - OS type and CPU architecture, and versions for the OS and Python runtime
-  - Possibly your input and the output
+  - Reliabot output, including error messages, warnings, and stack traces.
+    Setting `PYTHONWARNINGS=default` in the environment can show extra
+    diagnostics.
+  - Your `.pre-commit-config.yml`, `dependabot.yml`, and `.gitignore` files.
+  - If your GitHub repository is private, output from `tree` or `ls -R`.
+  - Versions of Reliabot, Python, and your Operating System (distribution).
+  - Output from `reliabot.py --self-test` (if relevant).
   - Can you reliably reproduce the problem? And can you also reproduce it with
     older Reliabot versions?
 
-### How to submit a good bug report
+### How to submit a good problem report
 
-> Don't report security related issues or vulnerabilities, or include sensitive
-> information in reports on the issue tracker, or elsewhere in public. Instead,
-> [contact the author by email][10]. If you can encrypt the email using
-> [their public key][11], or chat using Keybase, that's even better.
+> ⚠️Don't report security related issues or vulnerabilities, or include
+> sensitive information in reports on the issue tracker, or elsewhere in
+> public. Instead, [open a draft security advisory][11] and provide the
+> vulnerability information there. See the [Reliabot security policy][12] for
+> more details.
 
 The Reliabot project uses [GitHub issues][8] for tracking bugs. If you found a
 problem using Reliabot:
 
-- [Create an issue][2]. At first, it may not be clear whether it's a bug, so
-  please don't label the issue.
+- [Create an issue using the problem template][13]. It may not be clear yet
+  whether it's a bug, so please don't label the issue.
 - Describe the behavior you expect and the differences in the actual behavior.
 - Please provide as much context as possible and describe the *reproduction
   steps* that others can follow to recreate the issue. This may include your
   GitHub repository, probably its `pre-commit-config.yaml`, and definitely your
   `dependabot.yml` file.
-- For the best bug reports and fastest fixes, try to isolate the problem and
-  create a reduced test case.
+- For the best problem reports and fastest fixes, try to isolate the problem
+  and create a reduced test case.
 - Provide the information you collected in the previous section.
-- If would like to develop a fix for the bug, or already have a proposed
-  change, please mention this in the bug report.
+- If you would like to develop a fix for the problem, or already have a
+  proposed change, please mention this in the problem report.
 
 Once you have created the issue:
 
@@ -132,10 +141,8 @@ Once you have created the issue:
   mark the issue as **help wanted** or **invalid**. Until someone can reproduce
   the problem, they won't try to fix it.
 - Once they can reproduce the problem, they'll assign it to someone to
-  [implement a fix][12]. If you indicated interest in working on a fix, or that
+  [implement a fix][14]. If you indicated interest in working on a fix, or that
   you already have a proposed fix, they may assign it to you.
-
-<!--  TODO: create an issue template for bugs to provide the necessary information -->
 
 ## Suggesting enhancements
 
@@ -147,43 +154,68 @@ suggestion and how it relates to other approaches.
 ### Before suggesting an enhancement
 
 - Make sure you are using the latest Reliabot version.
-- Read the [documentation][6] carefully and see if the feature is already
-  provided
+- Read the [documentation][6] to see if Reliabot can already do what you want.
 - [Search the issues][8] to see if somebody already suggested this enhancement.
   If so, add a comment to that existing issue instead of opening a new one.
 - Find out whether your idea fits with the scope and aims of the project. It's
   up to you to make a strong case for the merits of this feature. Keep in mind
-  that features should be useful to the majority of users and not just a small
-  subset.
+  that features should be useful to many users and not just a few of them.
 
-### Writing a good enhancement issue
+### Writing a good enhancement suggestion
 
-The Reliabot project tracks [enhancement suggestions][13] with GitHub issues.
+The Reliabot project tracks [enhancement suggestions][15] with GitHub issues.
 To suggest an enhancement for Reliabot:
 
-- [Create an issue][2], labeling it as an 🔵 **enhancement**.
+- [Create an issue using the enhancement template][16], labeling it as an 🔵
+  **enhancement**.
 - Use a **clear and descriptive title** to identify the enhancement.
-- Provide a **step-by-step description of the suggested enhancement** with as
-  many details as possible.
-- **Describe the current behavior** and **explain which behavior you expected
-  to see instead** and why. You can also describe alternatives that don't work
-  for you.
-- You may want to **include screenshots** to demonstrate the steps or show
-  details of the enhancement.
-- **Explain why this enhancement would be useful** to most reliabot users. You
-  may also want to point out other projects that solved it better and which
-  could serve as inspiration.
-
-<!-- TODO: create an issue template for enhancement suggestions -->
+- Describe any problem the enhancement would solve, and explain how.
+- Provide a clear and concise **description of the suggested enhancement**.
+- **Describe the current behavior** and **explain the behavior you'd like to
+  see instead.** You can also describe alternative solutions that aren't as
+  good, and explain why.
+- **Explain why this enhancement would be useful** to many reliabot users.
 
 ## Becoming a contributor
 
 > #### Legal Notice
 >
-> By contributing code or documentation to this project, you certify, per the
-> [Developer Certificate of Origin][14] version 1.1 or later, that you have the
-> necessary rights to the content you contribute, and that they allow
-> distribution under the [Reliabot project license][15],
+> By contributing code or documentation to this project, you are certifying,
+> per the [Developer Certificate of Origin][17] version 1.1 or later, that you
+> have the necessary rights to the content you contribute, and that they allow
+> distribution under the [Reliabot project license][18],
+>
+> You do this by ["signing off" your commits][19]. "Signing off" isn't
+> cryptographic, it's just a line like "Signed-off-by: your name
+> <your.email@example.org>" at the end of a commit message. You can add it
+> manually when squash merging a PR, or by giving the `-s` or `--signoff`
+> option to `git commit`.
+
+### First contributions
+
+Unsure where to start contributing? Start by looking at Reliabot issues labeled
+[**good first issue**][20] or [**help wanted**][21].
+
+- **good first issue** – should only require a few lines of code and a test.
+- **help wanted** – more complex, requiring code design and Python experience.
+
+### Pre-commit setup
+
+Reliabot uses [pre-commit][22] to perform style checks and fixes. Whether you
+are contributing code or documentation, you should [install pre-commit][23] on
+your system, and then enable it for your local copy of the Reliabot repository:
+
+```console
+$ cd reliabot && pre-commit install
+pre-commit installed at .git/hooks/pre-commit
+```
+
+If you don't (or can't) install pre-commit on your system (say, if you're using
+the GitHub file editor in the web UI to fix a small typo), once you create a
+PR, the [pre-commit.ci][24] service runs the pre-commit checks for you and
+pushes fixes to your PRs for many style / formatting issues. Run `git pull` on
+your PR branch after the **pre-commit.ci - pr** checks are no longer pending,
+and show either success or failure.
 
 ### Contributing code and bug fixes
 
@@ -191,23 +223,82 @@ To suggest an enhancement for Reliabot:
 
 ### Improving the documentation
 
-<!-- TODO
-Updating, improving and correcting the documentation
+The documentation for Reliabot currently consists of a number of Markdown files
+in standard locations (README.md, CONTRIBUTING.md, SECURITY.md).
 
--->
+There is configuration and a Makefile for using [Vale][25] for checking prose
+style and suggest improvements to the documentation, as well as text in the
+GitHub issue templates. There is no CI integration for Vale, you have to
+install it yourself:
+
+- `brew install vale` on macOS
+
+Once you have installed Vale, you can run it with `make`.
+
+<!-- TODO: Integrate Vale into a CI pipeline -->
 
 ## Style guides
 
+[Pre-commit checks][26] cover most of the style guides below, and often
+auto-fix style issues, either as local changes in your copy of the Reliabot
+repository, or as commits that pre-commit.ci adds to your PR.
+
 ### Commit messages
 
-<!-- TODO
+- Limit the first line to 72 or fewer characters.
+- Start the first line with a [conventional commit type][27], like these
+  examples: `feat:` or `ci(pre-commit):`.
+  - _You can use [commitizen][28] or similar tools to help manage this._
+- Use the present tense ("Add feature" not "Added feature").
+- Use the imperative mood ("Move cursor to…" not "Moves cursor to…").
+- Reference issues and pull requests liberally after the first line.
 
--->
+### Python code
+
+Reliabot code uses [Black][28] style formatting. Pre-commit checks enforce this
+and some PEP code styles.
+
+### Shell code
+
+Reliabot pre-commit hooks format shell scripts with `shfmt -i 2 -ci`, and lint
+them with [`shellcheck`][22].
+
+### Markdown documentation
+
+Reliabot documentation uses GitHub Flavored Markdown, following the
+[Markdown style guide][29] implemented by [Executable Books mdformat][30], with
+some non-default `mdformat` style settings:
+
+- "Consecutive" numbering for [ordered lists][31] for compatibility with the
+  [markdownlint][32] checker, like this:
+  ```markdown
+  1. first
+  2. second
+  3. etcetera
+  ```
+- Word wrapping at 79 columns.
+- A pre-commit hook based on a Python script from a [decade-old blog post][33]
+  rewrites all [reference links][34] with numeric tags ordered by appearance in
+  the text.
+
+While these settings don't minimize Git diffs in line-by-line diff mode, they
+do maximize readability of the Markdown source files, and the
+`--word-diff=color` option for `git diff` generates usable diffs in most cases.
+
+Reliabot uses several `mdformat` plugins to auto-generate tables of contents,
+format Markdown tables, and to format code blocks with shell, Python, and
+configuration language tags.
+
+### Configuration files
+
+Reliabot uses [Prettier][35] to automatically format CFG, INI, JSON, TOML, and
+YAML configuration files. The only non-standard setting is to use single quotes
+in preference to double quotes for formats that allow this.
 
 ## Attribution
 
 The **contributing-gen** generator created the initial version of this file.
-[Make your own CONTRIBUTING.md][16] 📝
+[Make your own CONTRIBUTING.md][36] 📝
 
 [1]: #asking-a-question
 [2]: https://github.com/dupuy/reliabot/issues/new
@@ -216,12 +307,32 @@ The **contributing-gen** generator created the initial version of this file.
 [5]: #table-of-contents
 [6]: https://github.com/dupuy/reliabot#reliabot--maintain-github-dependabot-configuration
 [7]: https://github.com/dupuy/reliabot#faq
-[8]: https://github.com/dupuy/reliabot/issues?q=is%3Aissue
-[9]: https://github.com/dupuy/reliabot/issues?q=label%3Abug
-[10]: mailto:alex@dupuy.us
-[11]: https://keybase.io/dupuy
-[12]: #becoming-a-contributor
-[13]: https://github.com/dupuy/reliabot/issues?q=label%3Aenhancement
-[14]: https://developercertificate.org/
-[15]: https://github.com/dupuy/reliabot/blob/main/LICENSE
-[16]: https://github.com/bttger/contributing-gen
+[8]: https://github.com/dupuy/reliabot/issues?q=is%3Aissue+sort%3Aupdated-desc
+[9]: https://github.com/dupuy/reliabot/issues/new?assignees=&labels=question&projects=&template=question.md&title=Question+about+...
+[10]: https://github.com/dupuy/reliabot/issues?q=label%3Abug
+[11]: https://github.com/dupuy/reliabot/security/advisories/new
+[12]: https://github.com/dupuy/reliabot/security/policy
+[13]: https://github.com/dupuy/reliabot/issues/new?template=problem.md&title=Problem+with+%E2%80%A6
+[14]: #becoming-a-contributor
+[15]: https://github.com/dupuy/reliabot/issues?q=label%3Aenhancement
+[16]: https://github.com/dupuy/reliabot/issues/new?template=enhancement.md&title=Enhancement+to+https://github.com/dupuy/reliabot/issues/new?template=problem.md&title=Problem+with+%E2%80%A6
+[17]: https://developercertificate.org/
+[18]: https://github.com/dupuy/reliabot/blob/main/LICENSE
+[19]: https://stackoverflow.com/a/14044024
+[20]: https://github.com/dupuy/reliabot/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+sort%3Acomments-desc
+[21]: https://github.com/dupuy/reliabot/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22+sort%3Acomments-desc
+[22]: https://pre-commit.com/
+[23]: https://pre-commit.com/#install
+[24]: https://pre-commit.ci
+[25]: https://vale.sh/
+[26]: #pre-commit-setup
+[27]: https://www.conventionalcommits.org/en/v1.0.0/#summary
+[28]: https://commitizen-tools.github.io/commitizen/
+[29]: https://mdformat.readthedocs.io/en/stable/users/style.html
+[30]: https://github.com/executablebooks/mdformat
+[31]: https://mdformat.readthedocs.io/en/stable/users/style.html#ordered-lists
+[32]: https://github.com/markdownlint/markdownlint
+[33]: https://leancrew.com/all-this/2012/09/tidying-markdown-reference-links/
+[34]: https://mdformat.readthedocs.io/en/stable/users/style.html#reference-links
+[35]: https://prettier.io/docs/en/
+[36]: https://github.com/bttger/contributing-gen

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,11 +24,10 @@ everyone.
 > - Refer to Reliabot in your project's README
 > - Link to Reliabot in social media
 
-## Table of contents
+#### Table of contents
 
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=3 --minlevel=2 -->
 
-- [Table of contents](#table-of-contents)
 - [Asking a question](#asking-a-question)
 - [Reporting bugs](#reporting-bugs)
   - [Before submitting a bug report](#before-submitting-a-bug-report)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,31 @@
-<!-- omit in toc -->
 # Contributing to reliabot
 
 First off, thanks for taking the time to contribute! ❤️
 
-All types of contributions are encouraged and valued. See the [Table of Contents](#table-of-contents) for different ways to help and details about how this project handles them. Please make sure to read the relevant section before making your contribution. It will make it a lot easier for us maintainers and smooth out the experience for all involved. The community looks forward to your contributions. 🎉
+All types of contributions are encouraged and valued. See the
+[Table of Contents](#table-of-contents) for different ways to help and details
+about how this project handles them. Please make sure to read the relevant
+section before making your contribution. It will make it a lot easier for us
+maintainers and smooth out the experience for all involved. The community looks
+forward to your contributions. 🎉
 
-> And if you like the project, but just don't have time to contribute, that's fine. There are other easy ways to support the project and show your appreciation, which we would also be very happy about:
+> And if you like the project, but just don't have time to contribute, that's
+> fine. There are other easy ways to support the project and show your
+> appreciation, which we would also be very happy about:
+>
 > - Star the project
 > - Tweet about it
 > - Refer this project in your project's readme
 > - Mention the project at local meetups and tell your friends/colleagues
 
-<!-- omit in toc -->
 ## Table of Contents
 
+<!-- mdformat-toc start --slug=github --no-anchors --maxlevel=3 --minlevel=2 -->
+
+- [Table of Contents](#table-of-contents)
 - [I Have a Question](#i-have-a-question)
 - [I Want To Contribute](#i-want-to-contribute)
+  - [Legal Notice](#legal-notice)
   - [Reporting Bugs](#reporting-bugs)
   - [Suggesting Enhancements](#suggesting-enhancements)
   - [Your First Code Contribution](#your-first-code-contribution)
@@ -23,20 +33,28 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 - [Styleguides](#styleguides)
   - [Commit Messages](#commit-messages)
 - [Join The Project Team](#join-the-project-team)
+- [Attribution](#attribution)
 
-
+<!-- mdformat-toc end -->
 
 ## I Have a Question
 
-> If you want to ask a question, we assume that you have read the available [Documentation](https://github.com/dupuy/reliabot/blob/main/README.md).
+> If you want to ask a question, we assume that you have read the available
+> [Documentation](https://github.com/dupuy/reliabot/blob/main/README.md).
 
-Before you ask a question, it is best to search for existing [Issues](https://github.com/dupuy/reliabot/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
+Before you ask a question, it is best to search for existing
+[Issues](https://github.com/dupuy/reliabot/issues) that might help you. In case
+you have found a suitable issue and still need clarification, you can write
+your question in this issue. It is also advisable to search the internet for
+answers first.
 
-If you then still feel the need to ask a question and need clarification, we recommend the following:
+If you then still feel the need to ask a question and need clarification, we
+recommend the following:
 
 - Open an [Issue](https://github.com/dupuy/reliabot/issues/new).
 - Provide as much context as you can about what you're running into.
-- Provide project and platform versions (nodejs, npm, etc), depending on what seems relevant.
+- Provide project and platform versions (nodejs, npm, etc), depending on what
+  seems relevant.
 
 We will then take care of the issue as soon as possible.
 
@@ -57,95 +75,153 @@ Depending on how large the project is, you may want to outsource the questioning
 
 ## I Want To Contribute
 
-> ### Legal Notice <!-- omit in toc -->
-> When contributing to this project, you must agree that you have authored 100% of the content, that you have the necessary rights to the content and that the content you contribute may be provided under the project license.
+> ### Legal Notice
+>
+> When contributing to this project, you must agree that you have authored 100%
+> of the content, that you have the necessary rights to the content and that
+> the content you contribute may be provided under the project license.
 
 ### Reporting Bugs
 
-<!-- omit in toc -->
 #### Before Submitting a Bug Report
 
-A good bug report shouldn't leave others needing to chase you up for more information. Therefore, we ask you to investigate carefully, collect information and describe the issue in detail in your report. Please complete the following steps in advance to help us fix any potential bug as fast as possible.
+A good bug report shouldn't leave others needing to chase you up for more
+information. Therefore, we ask you to investigate carefully, collect
+information and describe the issue in detail in your report. Please complete
+the following steps in advance to help us fix any potential bug as fast as
+possible.
 
 - Make sure that you are using the latest version.
-- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](https://github.com/dupuy/reliabot/blob/main/README.md). If you are looking for support, you might want to check [this section](#i-have-a-question)).
-- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/dupuy/reliabot/issues?q=label%3Abug).
-- Also make sure to search the internet (including Stack Overflow) to see if users outside of the GitHub community have discussed the issue.
+- Determine if your bug is really a bug and not an error on your side e.g.
+  using incompatible environment components/versions (Make sure that you have
+  read the
+  [documentation](https://github.com/dupuy/reliabot/blob/main/README.md). If
+  you are looking for support, you might want to check
+  [this section](#i-have-a-question)).
+- To see if other users have experienced (and potentially already solved) the
+  same issue you are having, check if there is not already a bug report
+  existing for your bug or error in the
+  [bug tracker](https://github.com/dupuy/reliabot/issues?q=label%3Abug).
+- Also make sure to search the internet (including Stack Overflow) to see if
+  users outside of the GitHub community have discussed the issue.
 - Collect information about the bug:
   - Stack trace (Traceback)
   - OS, Platform and Version (Windows, Linux, macOS, x86, ARM)
-  - Version of the interpreter, compiler, SDK, runtime environment, package manager, depending on what seems relevant.
+  - Version of the interpreter, compiler, SDK, runtime environment, package
+    manager, depending on what seems relevant.
   - Possibly your input and the output
-  - Can you reliably reproduce the issue? And can you also reproduce it with older versions?
+  - Can you reliably reproduce the issue? And can you also reproduce it with
+    older versions?
 
-<!-- omit in toc -->
 #### How Do I Submit a Good Bug Report?
 
-> You must never report security related issues, vulnerabilities or bugs including sensitive information to the issue tracker, or elsewhere in public. Instead sensitive bugs must be sent by email to <>.
+> You must never report security related issues, vulnerabilities or bugs
+> including sensitive information to the issue tracker, or elsewhere in public.
+> Instead sensitive bugs must be sent by email to \<>.
+
 <!-- You may add a PGP key to allow the messages to be sent encrypted as well. -->
 
-We use GitHub issues to track bugs and errors. If you run into an issue with the project:
+We use GitHub issues to track bugs and errors. If you run into an issue with
+the project:
 
-- Open an [Issue](https://github.com/dupuy/reliabot/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
+- Open an [Issue](https://github.com/dupuy/reliabot/issues/new). (Since we
+  can't be sure at this point whether it is a bug or not, we ask you not to
+  talk about a bug yet and not to label the issue.)
 - Explain the behavior you would expect and the actual behavior.
-- Please provide as much context as possible and describe the *reproduction steps* that someone else can follow to recreate the issue on their own. This usually includes your code. For good bug reports you should isolate the problem and create a reduced test case.
+- Please provide as much context as possible and describe the *reproduction
+  steps* that someone else can follow to recreate the issue on their own. This
+  usually includes your code. For good bug reports you should isolate the
+  problem and create a reduced test case.
 - Provide the information you collected in the previous section.
 
 Once it's filed:
 
 - The project team will label the issue accordingly.
-- A team member will try to reproduce the issue with your provided steps. If there are no reproduction steps or no obvious way to reproduce the issue, the team will ask you for those steps and mark the issue as `needs-repro`. Bugs with the `needs-repro` tag will not be addressed until they are reproduced.
-- If the team is able to reproduce the issue, it will be marked `needs-fix`, as well as possibly other tags (such as `critical`), and the issue will be left to be [implemented by someone](#your-first-code-contribution).
+- A team member will try to reproduce the issue with your provided steps. If
+  there are no reproduction steps or no obvious way to reproduce the issue, the
+  team will ask you for those steps and mark the issue as `needs-repro`. Bugs
+  with the `needs-repro` tag will not be addressed until they are reproduced.
+- If the team is able to reproduce the issue, it will be marked `needs-fix`, as
+  well as possibly other tags (such as `critical`), and the issue will be left
+  to be [implemented by someone](#your-first-code-contribution).
 
 <!-- You might want to create an issue template for bugs and errors that can be used as a guide and that defines the structure of the information to be included. If you do so, reference it here in the description. -->
 
-
 ### Suggesting Enhancements
 
-This section guides you through submitting an enhancement suggestion for reliabot, **including completely new features and minor improvements to existing functionality**. Following these guidelines will help maintainers and the community to understand your suggestion and find related suggestions.
+This section guides you through submitting an enhancement suggestion for
+reliabot, **including completely new features and minor improvements to
+existing functionality**. Following these guidelines will help maintainers and
+the community to understand your suggestion and find related suggestions.
 
-<!-- omit in toc -->
 #### Before Submitting an Enhancement
 
 - Make sure that you are using the latest version.
-- Read the [documentation](https://github.com/dupuy/reliabot/blob/main/README.md) carefully and find out if the functionality is already covered, maybe by an individual configuration.
-- Perform a [search](https://github.com/dupuy/reliabot/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
-- Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on/plugin library.
+- Read the
+  [documentation](https://github.com/dupuy/reliabot/blob/main/README.md)
+  carefully and find out if the functionality is already covered, maybe by an
+  individual configuration.
+- Perform a [search](https://github.com/dupuy/reliabot/issues) to see if the
+  enhancement has already been suggested. If it has, add a comment to the
+  existing issue instead of opening a new one.
+- Find out whether your idea fits with the scope and aims of the project. It's
+  up to you to make a strong case to convince the project's developers of the
+  merits of this feature. Keep in mind that we want features that will be
+  useful to the majority of our users and not just a small subset. If you're
+  just targeting a minority of users, consider writing an add-on/plugin
+  library.
 
-<!-- omit in toc -->
 #### How Do I Submit a Good Enhancement Suggestion?
 
-Enhancement suggestions are tracked as [GitHub issues](https://github.com/dupuy/reliabot/issues).
+Enhancement suggestions are tracked as
+[GitHub issues](https://github.com/dupuy/reliabot/issues).
 
-- Use a **clear and descriptive title** for the issue to identify the suggestion.
-- Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
-- **Describe the current behavior** and **explain which behavior you expected to see instead** and why. At this point you can also tell which alternatives do not work for you.
-- You may want to **include screenshots and animated GIFs** which help you demonstrate the steps or point out the part which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux. <!-- this should only be included if the project has a GUI -->
-- **Explain why this enhancement would be useful** to most reliabot users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
+- Use a **clear and descriptive title** for the issue to identify the
+  suggestion.
+- Provide a **step-by-step description of the suggested enhancement** in as
+  many details as possible.
+- **Describe the current behavior** and **explain which behavior you expected
+  to see instead** and why. At this point you can also tell which alternatives
+  do not work for you.
+- You may want to **include screenshots and animated GIFs** which help you
+  demonstrate the steps or point out the part which the suggestion is related
+  to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs
+  on macOS and Windows, and
+  [this tool](https://github.com/colinkeenan/silentcast) on Linux.
+      <!-- this should only be included if the project has a GUI -->
+- **Explain why this enhancement would be useful** to most reliabot users. You
+  may also want to point out the other projects that solved it better and which
+  could serve as inspiration.
 
 <!-- You might want to create an issue template for enhancement suggestions that can be used as a guide and that defines the structure of the information to be included. If you do so, reference it here in the description. -->
 
 ### Your First Code Contribution
+
 <!-- TODO
 include Setup of env, IDE and typical getting started instructions?
 
 -->
 
 ### Improving The Documentation
+
 <!-- TODO
 Updating, improving and correcting the documentation
 
 -->
 
 ## Styleguides
+
 ### Commit Messages
+
 <!-- TODO
 
 -->
 
 ## Join The Project Team
+
 <!-- TODO -->
 
-<!-- omit in toc -->
 ## Attribution
-This guide is based on the **contributing-gen**. [Make your own](https://github.com/bttger/contributing-gen)!
+
+This guide is based on the **contributing-gen**.
+[Make your own](https://github.com/bttger/contributing-gen)!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,14 +3,17 @@
 🙏Thanks in advance for your contributions ❤️
 
 There are _many_ ways to contribute – one of the best is just using Reliabot
-for your projects. [Open an issue][4] if you have a problem, or if you think of
-a way to improve Reliabot. Fix a typo or broken URL in the docs, or add support
-for a software distribution packager – no contribution is too small or large.
+for your projects – and no contribution is too small or too large.
 
-See the [Table of contents][1] for different ways to help and details about how
-this project handles them. _Please read the relevant section before
-contributing_. This makes it easier for the team and improves the experience
-for everyone.
+- [Ask a question][1] about using Reliabot.
+- [Open an issue][2] about a problem, or for a way to improve Reliabot.
+- [Improve the docs][3] by fixing typos and broken links, or writing a HowTo.
+- [Write code][4] to add a feature or support for a distribution packager.
+
+See the [Table of contents][5] for different ways to help and details about how
+to contribute to Reliabot. _Please read the relevant section before
+contributing_. This makes the process easier and improves the experience for
+everyone.
 
 👀 Looking forward to your contributions 🎉
 
@@ -19,212 +22,207 @@ for everyone.
 >
 > - Star the Reliabot GitHub project
 > - Refer to Reliabot in your project's README
-> - Mention Reliabot in social media
+> - Link to Reliabot in social media
 
 ## Table of contents
 
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=3 --minlevel=2 -->
 
 - [Table of contents](#table-of-contents)
-- [I Have a Question](#i-have-a-question)
-- [I Want To Contribute](#i-want-to-contribute)
-  - [Legal Notice](#legal-notice)
-  - [Reporting Bugs](#reporting-bugs)
-  - [Suggesting Enhancements](#suggesting-enhancements)
-  - [Your First Code Contribution](#your-first-code-contribution)
-  - [Improving The Documentation](#improving-the-documentation)
-- [Styleguides](#styleguides)
-  - [Commit Messages](#commit-messages)
-- [Join The Project Team](#join-the-project-team)
+- [Asking a question](#asking-a-question)
+- [Reporting bugs](#reporting-bugs)
+  - [Before submitting a bug report](#before-submitting-a-bug-report)
+  - [How to submit a good bug report](#how-to-submit-a-good-bug-report)
+- [Suggesting enhancements](#suggesting-enhancements)
+  - [Before suggesting an enhancement](#before-suggesting-an-enhancement)
+  - [Writing a good enhancement issue](#writing-a-good-enhancement-issue)
+- [Becoming a contributor](#becoming-a-contributor)
+  - [Contributing code and bug fixes](#contributing-code-and-bug-fixes)
+  - [Improving the documentation](#improving-the-documentation)
+- [Style guides](#style-guides)
+  - [Commit messages](#commit-messages)
 - [Attribution](#attribution)
 
 <!-- mdformat-toc end -->
 
-## I Have a Question
+## Asking a question
 
-> If you want to ask a question, we assume that you have read the available
-> [Documentation][2].
+> ℹ️ If you have a Reliabot question, take a look at the [README][6] and its
+> [FAQ][7] to see if it's answered there.
 
-Before you ask a question, it is best to search for existing [Issues][3] that
-might help you. In case you have found a suitable issue and still need
-clarification, you can write your question in this issue. It is also advisable
-to search the internet for answers first.
+Before asking a question, search for [existing issues][8] that are similar. If
+you find a relevant issue but still need clarification, ask your question in
+that issue. A few internet search queries may also turn up an answer quickly.
 
-If you then still feel the need to ask a question and need clarification, we
-recommend the following:
+If you don't find an answer or an existing issue, follow these steps to ask
+your question:
 
-- Open an [Issue][4].
-- Provide as much context as you can about what you're running into.
-- Provide project and platform versions (nodejs, npm, etc), depending on what
-  seems relevant.
+- [Create a new issue][2], labeling it as a 🟣 **question**.
+- Provide as much context as you can for your question.
+  - Reliabot version
+  - Whether you're running Reliabot with pre-commit or on the command line
+  - OS type and CPU architecture, and versions for the OS and Python runtime
+- Explain what you're trying to do, and what you don't understand.
 
-We will then take care of the issue as soon as possible.
+Someone should respond to the issue as soon as possible. Be patient. 🕗😊
 
-<!--
-You might want to create a separate issue tag for questions and include it in this description. People should then tag their issues accordingly.
+## Reporting bugs
 
-Depending on how large the project is, you may want to outsource the questioning, e.g. to Stack Overflow or Gitter. You may add additional contact and information possibilities:
-- IRC
-- Slack
-- Gitter
-- Stack Overflow tag
-- Blog
-- FAQ
-- Roadmap
-- E-Mail List
-- Forum
--->
+### Before submitting a bug report
 
-## I Want To Contribute
+A good bug report shouldn't force others to contact you for critical missing
+information. Please investigate carefully, find examples and counter-examples,
+and describe the problem in detail. Completing the following steps in advance
+helps to fix any potential bug as fast as possible.
 
-> ### Legal Notice
->
-> When contributing to this project, you must agree that you have authored 100%
-> of the content, that you have the necessary rights to the content and that
-> the content you contribute may be provided under the project license.
-
-### Reporting Bugs
-
-#### Before Submitting a Bug Report
-
-A good bug report shouldn't leave others needing to chase you up for more
-information. Therefore, we ask you to investigate carefully, collect
-information and describe the issue in detail in your report. Please complete
-the following steps in advance to help us fix any potential bug as fast as
-possible.
-
-- Make sure that you are using the latest version.
-- Determine if your bug is really a bug and not an error on your side e.g.
-  using incompatible environment components/versions (Make sure that you have
-  read the [documentation][2]. If you are looking for support, you might want
-  to check [this section][5]).
-- To see if other users have experienced (and potentially already solved) the
-  same issue you are having, check if there is not already a bug report
-  existing for your bug or error in the [bug tracker][6].
-- Also make sure to search the internet (including Stack Overflow) to see if
-  users outside of the GitHub community have discussed the issue.
+- Make sure you are using the latest Reliabot version.
+- Confirm that your problem is really a bug and not an error on your part, such
+  as using Reliabot with unsupported environments or versions. Reading the
+  [documentation][6] can help. If you need support, consider just
+  [asking a question][1] first.
+- To see if other users have experienced (and perhaps already solved) the same
+  problem as you, search the [bug tracker][9] for similar issues or error
+  messages.
+- Searching the internet (especially Stack Overflow) can help you find any
+  users of other tools, or in other forums, who have run into a similar
+  problem.
 - Collect information about the bug:
-  - Stack trace (Traceback)
-  - OS, Platform and Version (Windows, Linux, macOS, x86, ARM)
-  - Version of the interpreter, compiler, SDK, runtime environment, package
-    manager, depending on what seems relevant.
+  - Specific Reliabot command line and context.
+  - All error messages and warnings, including stack traces. Setting
+    `PYTHONWARNINGS=default` in the environment can show extra diagnostics.
+  - OS type and CPU architecture, and versions for the OS and Python runtime
   - Possibly your input and the output
-  - Can you reliably reproduce the issue? And can you also reproduce it with
-    older versions?
+  - Can you reliably reproduce the problem? And can you also reproduce it with
+    older Reliabot versions?
 
-#### How Do I Submit a Good Bug Report?
+### How to submit a good bug report
 
-> You must never report security related issues, vulnerabilities or bugs
-> including sensitive information to the issue tracker, or elsewhere in public.
-> Instead sensitive bugs must be sent by email to \<>.
+> Don't report security related issues or vulnerabilities, or include sensitive
+> information in reports on the issue tracker, or elsewhere in public. Instead,
+> [contact the author by email][10]. If you can encrypt the email using
+> [their public key][11], or chat using Keybase, that's even better.
 
-<!-- You may add a PGP key to allow the messages to be sent encrypted as well. -->
+The Reliabot project uses [GitHub issues][8] for tracking bugs. If you found a
+problem using Reliabot:
 
-We use GitHub issues to track bugs and errors. If you run into an issue with
-the project:
-
-- Open an [Issue][4]. (Since we can't be sure at this point whether it is a bug
-  or not, we ask you not to talk about a bug yet and not to label the issue.)
-- Explain the behavior you would expect and the actual behavior.
+- [Create an issue][2]. At first, it may not be clear whether it's a bug, so
+  please don't label the issue.
+- Describe the behavior you expect and the differences in the actual behavior.
 - Please provide as much context as possible and describe the *reproduction
-  steps* that someone else can follow to recreate the issue on their own. This
-  usually includes your code. For good bug reports you should isolate the
-  problem and create a reduced test case.
+  steps* that others can follow to recreate the issue. This may include your
+  GitHub repository, probably its `pre-commit-config.yaml`, and definitely your
+  `dependabot.yml` file.
+- For the best bug reports and fastest fixes, try to isolate the problem and
+  create a reduced test case.
 - Provide the information you collected in the previous section.
+- If would like to develop a fix for the bug, or already have a proposed
+  change, please mention this in the bug report.
 
-Once it's filed:
+Once you have created the issue:
 
-- The project team will label the issue accordingly.
-- A team member will try to reproduce the issue with your provided steps. If
-  there are no reproduction steps or no obvious way to reproduce the issue, the
-  team will ask you for those steps and mark the issue as `needs-repro`. Bugs
-  with the `needs-repro` tag will not be addressed until they are reproduced.
-- If the team is able to reproduce the issue, it will be marked `needs-fix`, as
-  well as possibly other tags (such as `critical`), and the issue will be left
-  to be [implemented by someone][7].
+- Someone reviews it, labeling the issue with one of these:
+  - 🔴 **bug** – if it's really a Reliabot bug or error
+  - ⚪️ **duplicate** – if there's already an issue for this
+  - 🔵 **enhancement** – if Reliabot works as intended, but could work better
+  - 🔵 **help wanted** – if they aren't sure what to label it
+  - ⚪️ **invalid** if this is spam or nonsense or not even a question
+  - 🟣 **question** – if it's not a bug, and you should do something differently
+  - ⚪️ **wontfix** – if Reliabot is working as intended, and won't change
+- They try to reproduce the problem using your provided steps. If there are no
+  steps or obvious way to reproduce it, they may ask you for those steps and
+  mark the issue as **help wanted** or **invalid**. Until someone can reproduce
+  the problem, they won't try to fix it.
+- Once they can reproduce the problem, they'll assign it to someone to
+  [implement a fix][12]. If you indicated interest in working on a fix, or that
+  you already have a proposed fix, they may assign it to you.
 
-<!-- You might want to create an issue template for bugs and errors that can be used as a guide and that defines the structure of the information to be included. If you do so, reference it here in the description. -->
+<!--  TODO: create an issue template for bugs to provide the necessary information -->
 
-### Suggesting Enhancements
+## Suggesting enhancements
 
-This section guides you through submitting an enhancement suggestion for
-reliabot, **including completely new features and minor improvements to
-existing functionality**. Following these guidelines will help maintainers and
-the community to understand your suggestion and find related suggestions.
+This section shows you how to submit an enhancement suggestion for Reliabot,
+**including completely new features and minor improvements to existing
+capabilities**. Following these guidelines helps others understand your
+suggestion and how it relates to other approaches.
 
-#### Before Submitting an Enhancement
+### Before suggesting an enhancement
 
-- Make sure that you are using the latest version.
-- Read the [documentation][2] carefully and find out if the functionality is
-  already covered, maybe by an individual configuration.
-- Perform a [search][3] to see if the enhancement has already been suggested.
-  If it has, add a comment to the existing issue instead of opening a new one.
+- Make sure you are using the latest Reliabot version.
+- Read the [documentation][6] carefully and see if the feature is already
+  provided
+- [Search the issues][8] to see if somebody already suggested this enhancement.
+  If so, add a comment to that existing issue instead of opening a new one.
 - Find out whether your idea fits with the scope and aims of the project. It's
-  up to you to make a strong case to convince the project's developers of the
-  merits of this feature. Keep in mind that we want features that will be
-  useful to the majority of our users and not just a small subset. If you're
-  just targeting a minority of users, consider writing an add-on/plugin
-  library.
+  up to you to make a strong case for the merits of this feature. Keep in mind
+  that features should be useful to the majority of users and not just a small
+  subset.
 
-#### How Do I Submit a Good Enhancement Suggestion?
+### Writing a good enhancement issue
 
-Enhancement suggestions are tracked as [GitHub issues][3].
+The Reliabot project tracks [enhancement suggestions][13] with GitHub issues.
+To suggest an enhancement for Reliabot:
 
-- Use a **clear and descriptive title** for the issue to identify the
-  suggestion.
-- Provide a **step-by-step description of the suggested enhancement** in as
+- [Create an issue][2], labeling it as an 🔵 **enhancement**.
+- Use a **clear and descriptive title** to identify the enhancement.
+- Provide a **step-by-step description of the suggested enhancement** with as
   many details as possible.
 - **Describe the current behavior** and **explain which behavior you expected
-  to see instead** and why. At this point you can also tell which alternatives
-  do not work for you.
-- You may want to **include screenshots and animated GIFs** which help you
-  demonstrate the steps or point out the part which the suggestion is related
-  to. You can use [this tool][8] to record GIFs on macOS and Windows, and
-  [this tool][9] on Linux.
-      <!-- this should only be included if the project has a GUI -->
+  to see instead** and why. You can also describe alternatives that don't work
+  for you.
+- You may want to **include screenshots** to demonstrate the steps or show
+  details of the enhancement.
 - **Explain why this enhancement would be useful** to most reliabot users. You
-  may also want to point out the other projects that solved it better and which
+  may also want to point out other projects that solved it better and which
   could serve as inspiration.
 
-<!-- You might want to create an issue template for enhancement suggestions that can be used as a guide and that defines the structure of the information to be included. If you do so, reference it here in the description. -->
+<!-- TODO: create an issue template for enhancement suggestions -->
 
-### Your First Code Contribution
+## Becoming a contributor
 
-<!-- TODO
-include Setup of env, IDE and typical getting started instructions?
+> #### Legal Notice
+>
+> By contributing code or documentation to this project, you certify, per the
+> [Developer Certificate of Origin][14] version 1.1 or later, that you have the
+> necessary rights to the content you contribute, and that they allow
+> distribution under the [Reliabot project license][15],
 
--->
+### Contributing code and bug fixes
 
-### Improving The Documentation
+<!-- TODO include env setup, IDE and typical getting started instructions? -->
+
+### Improving the documentation
 
 <!-- TODO
 Updating, improving and correcting the documentation
 
 -->
 
-## Styleguides
+## Style guides
 
-### Commit Messages
+### Commit messages
 
 <!-- TODO
 
 -->
 
-## Join The Project Team
-
-<!-- TODO -->
-
 ## Attribution
 
-This guide is based on the **contributing-gen**. [Make your own][10]!
+The **contributing-gen** generator created the initial version of this file.
+[Make your own CONTRIBUTING.md][16] 📝
 
-[1]: #table-of-contents
-[2]: https://github.com/dupuy/reliabot/blob/main/README.md
-[3]: https://github.com/dupuy/reliabot/issues
-[4]: https://github.com/dupuy/reliabot/issues/new
-[5]: #i-have-a-question
-[6]: https://github.com/dupuy/reliabot/issues?q=label%3Abug
-[7]: #your-first-code-contribution
-[8]: https://www.cockos.com/licecap/
-[9]: https://github.com/colinkeenan/silentcast
-[10]: https://github.com/bttger/contributing-gen
+[1]: #asking-a-question
+[2]: https://github.com/dupuy/reliabot/issues/new
+[3]: #improving-the-documentation
+[4]: #contributing-code-and-bug-fixes
+[5]: #table-of-contents
+[6]: https://github.com/dupuy/reliabot#reliabot--maintain-github-dependabot-configuration
+[7]: https://github.com/dupuy/reliabot#faq
+[8]: https://github.com/dupuy/reliabot/issues?q=is%3Aissue
+[9]: https://github.com/dupuy/reliabot/issues?q=label%3Abug
+[10]: mailto:alex@dupuy.us
+[11]: https://keybase.io/dupuy
+[12]: #becoming-a-contributor
+[13]: https://github.com/dupuy/reliabot/issues?q=label%3Aenhancement
+[14]: https://developercertificate.org/
+[15]: https://github.com/dupuy/reliabot/blob/main/LICENSE
+[16]: https://github.com/bttger/contributing-gen

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,11 +3,11 @@
 First off, thanks for taking the time to contribute! ❤️
 
 All types of contributions are encouraged and valued. See the
-[Table of Contents](#table-of-contents) for different ways to help and details
-about how this project handles them. Please make sure to read the relevant
-section before making your contribution. It will make it a lot easier for us
-maintainers and smooth out the experience for all involved. The community looks
-forward to your contributions. 🎉
+[Table of Contents][1] for different ways to help and details about how this
+project handles them. Please make sure to read the relevant section before
+making your contribution. It will make it a lot easier for us maintainers and
+smooth out the experience for all involved. The community looks forward to your
+contributions. 🎉
 
 > And if you like the project, but just don't have time to contribute, that's
 > fine. There are other easy ways to support the project and show your
@@ -40,18 +40,17 @@ forward to your contributions. 🎉
 ## I Have a Question
 
 > If you want to ask a question, we assume that you have read the available
-> [Documentation](https://github.com/dupuy/reliabot/blob/main/README.md).
+> [Documentation][2].
 
-Before you ask a question, it is best to search for existing
-[Issues](https://github.com/dupuy/reliabot/issues) that might help you. In case
-you have found a suitable issue and still need clarification, you can write
-your question in this issue. It is also advisable to search the internet for
-answers first.
+Before you ask a question, it is best to search for existing [Issues][3] that
+might help you. In case you have found a suitable issue and still need
+clarification, you can write your question in this issue. It is also advisable
+to search the internet for answers first.
 
 If you then still feel the need to ask a question and need clarification, we
 recommend the following:
 
-- Open an [Issue](https://github.com/dupuy/reliabot/issues/new).
+- Open an [Issue][4].
 - Provide as much context as you can about what you're running into.
 - Provide project and platform versions (nodejs, npm, etc), depending on what
   seems relevant.
@@ -94,14 +93,11 @@ possible.
 - Make sure that you are using the latest version.
 - Determine if your bug is really a bug and not an error on your side e.g.
   using incompatible environment components/versions (Make sure that you have
-  read the
-  [documentation](https://github.com/dupuy/reliabot/blob/main/README.md). If
-  you are looking for support, you might want to check
-  [this section](#i-have-a-question)).
+  read the [documentation][2]. If you are looking for support, you might want
+  to check [this section][5]).
 - To see if other users have experienced (and potentially already solved) the
   same issue you are having, check if there is not already a bug report
-  existing for your bug or error in the
-  [bug tracker](https://github.com/dupuy/reliabot/issues?q=label%3Abug).
+  existing for your bug or error in the [bug tracker][6].
 - Also make sure to search the internet (including Stack Overflow) to see if
   users outside of the GitHub community have discussed the issue.
 - Collect information about the bug:
@@ -124,9 +120,8 @@ possible.
 We use GitHub issues to track bugs and errors. If you run into an issue with
 the project:
 
-- Open an [Issue](https://github.com/dupuy/reliabot/issues/new). (Since we
-  can't be sure at this point whether it is a bug or not, we ask you not to
-  talk about a bug yet and not to label the issue.)
+- Open an [Issue][4]. (Since we can't be sure at this point whether it is a bug
+  or not, we ask you not to talk about a bug yet and not to label the issue.)
 - Explain the behavior you would expect and the actual behavior.
 - Please provide as much context as possible and describe the *reproduction
   steps* that someone else can follow to recreate the issue on their own. This
@@ -143,7 +138,7 @@ Once it's filed:
   with the `needs-repro` tag will not be addressed until they are reproduced.
 - If the team is able to reproduce the issue, it will be marked `needs-fix`, as
   well as possibly other tags (such as `critical`), and the issue will be left
-  to be [implemented by someone](#your-first-code-contribution).
+  to be [implemented by someone][7].
 
 <!-- You might want to create an issue template for bugs and errors that can be used as a guide and that defines the structure of the information to be included. If you do so, reference it here in the description. -->
 
@@ -157,13 +152,10 @@ the community to understand your suggestion and find related suggestions.
 #### Before Submitting an Enhancement
 
 - Make sure that you are using the latest version.
-- Read the
-  [documentation](https://github.com/dupuy/reliabot/blob/main/README.md)
-  carefully and find out if the functionality is already covered, maybe by an
-  individual configuration.
-- Perform a [search](https://github.com/dupuy/reliabot/issues) to see if the
-  enhancement has already been suggested. If it has, add a comment to the
-  existing issue instead of opening a new one.
+- Read the [documentation][2] carefully and find out if the functionality is
+  already covered, maybe by an individual configuration.
+- Perform a [search][3] to see if the enhancement has already been suggested.
+  If it has, add a comment to the existing issue instead of opening a new one.
 - Find out whether your idea fits with the scope and aims of the project. It's
   up to you to make a strong case to convince the project's developers of the
   merits of this feature. Keep in mind that we want features that will be
@@ -173,8 +165,7 @@ the community to understand your suggestion and find related suggestions.
 
 #### How Do I Submit a Good Enhancement Suggestion?
 
-Enhancement suggestions are tracked as
-[GitHub issues](https://github.com/dupuy/reliabot/issues).
+Enhancement suggestions are tracked as [GitHub issues][3].
 
 - Use a **clear and descriptive title** for the issue to identify the
   suggestion.
@@ -185,9 +176,8 @@ Enhancement suggestions are tracked as
   do not work for you.
 - You may want to **include screenshots and animated GIFs** which help you
   demonstrate the steps or point out the part which the suggestion is related
-  to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs
-  on macOS and Windows, and
-  [this tool](https://github.com/colinkeenan/silentcast) on Linux.
+  to. You can use [this tool][8] to record GIFs on macOS and Windows, and
+  [this tool][9] on Linux.
       <!-- this should only be included if the project has a GUI -->
 - **Explain why this enhancement would be useful** to most reliabot users. You
   may also want to point out the other projects that solved it better and which
@@ -223,5 +213,15 @@ Updating, improving and correcting the documentation
 
 ## Attribution
 
-This guide is based on the **contributing-gen**.
-[Make your own](https://github.com/bttger/contributing-gen)!
+This guide is based on the **contributing-gen**. [Make your own][10]!
+
+[1]: #table-of-contents
+[2]: https://github.com/dupuy/reliabot/blob/main/README.md
+[3]: https://github.com/dupuy/reliabot/issues
+[4]: https://github.com/dupuy/reliabot/issues/new
+[5]: #i-have-a-question
+[6]: https://github.com/dupuy/reliabot/issues?q=label%3Abug
+[7]: #your-first-code-contribution
+[8]: https://www.cockos.com/licecap/
+[9]: https://github.com/colinkeenan/silentcast
+[10]: https://github.com/bttger/contributing-gen

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,10 @@ STYLES = $(addprefix styles/,${PACKAGES})
 
 $(TOOLS): ${TOOL_DIR}/pipx
 	${TOOL_DIR}/pipx install --force $@
+	${TOOL_DIR}/pipx ensurepath
 	@# vale self-downloads on first install
-	@case $@ in vale) vale sync || pipx uninstall $@;; esac
+	@PATH=$(TOOL_DIR):$$PATH; \
+	 case $@ in vale) vale sync || pipx uninstall $@;; esac
 
 ${TOOL_DIR}/pipx:
 	python3 -m pip install --upgrade --user pip

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![pre-commit enabled](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/dupuy/reliabot/main.svg)](https://results.pre-commit.ci/latest/github/dupuy/reliabot/main)
 
-# Reliabot – Maintain GitHub Dependabot configuration
+# Reliabot – Maintain Dependabot configuration
 
 Reliabot is a tool that helps maintain Dependabot configurations in your GitHub
 repository. This is especially helpful for [Terraform][1] “Infrastructure as
@@ -123,9 +123,10 @@ pip3 install reliabot
 
 #### Installing with RE2
 
-You can improve the reliability and performance of Reliabot with Python RE2
-regex support in its environment. This also requires the C++ RE2 library (run
-`brew install re2` or use Linux/BSD package tools to install `re2`).
+You can improve the reliability and performance of Reliabot, and prevent
+warning messages, by installing a Python RE2 regular expression package. These
+require installation of the C++ RE2 library (run `brew install re2`, or use
+Linux/BSD tools to install the `re2` package).
 
 > ⚠️The `pyre2-wheels` extra (which depends on [pyre2-updated][7]) doesn't work
 > for Python 3.12 – it only supports Python 3.6 to 3.11. If you need Python

--- a/humans.txt
+++ b/humans.txt
@@ -1,0 +1,3 @@
+/* TEAM */
+  Original Author: dupuy (Alexander Dupuy)
+  First Contributor: appills

--- a/styles/Reliabot/SpellCheck.yml
+++ b/styles/Reliabot/SpellCheck.yml
@@ -1,0 +1,4 @@
+extends: spelling
+message: "Did you really mean '%s'?"
+level: error
+ignore: vocab.txt

--- a/styles/config/vocabularies/Reliabot/accept.txt
+++ b/styles/config/vocabularies/Reliabot/accept.txt
@@ -4,11 +4,14 @@ INI
 Keybase
 Makefile
 PEP
+Pylint
 Quis
 TOML
 [Dd]ependabot
 [Rr]eliabot
 commitizen
+docstring
+doctest
 formatters
 ipsos
 markdownlint

--- a/styles/config/vocabularies/Reliabot/accept.txt
+++ b/styles/config/vocabularies/Reliabot/accept.txt
@@ -1,5 +1,3 @@
-[Dd]ependabot
-[Rr]eliabot
 BSD
 CFG
 INI
@@ -8,11 +6,13 @@ Makefile
 PEP
 Quis
 TOML
+[Dd]ependabot
+[Rr]eliabot
 commitizen
 formatters
+ipsos
 markdownlint
 mdformat
-ipsos
 renovatores
 virtualenv
 wontfix


### PR DESCRIPTION
Initial version from the [generator](https://generator.contributing.md/#) at
[contributing.md](https://contributing.md/how-to-build-contributing-md/).

- Markdown refactoring per pre-commit style
- Switch to sequentially numbered reference-style links
- Substantial rewriting and fixing of Vale style violations

[Review CONTRIBUTING.md as formatted text](https://github.com/dupuy/reliabot/pull/23/files?short_path=eca12c0#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055).

There is some content in "Becoming a Contributor" and following sections but
some parts are just stubs as the generator template had no ontent for those.