### PR TITLE
docs: explain reliabot options and verify console examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ dist/
 .coverage
 .mypy.cache/
 .tox/
+*.md.sh
 
 # MacOS
 .DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -201,7 +201,11 @@ repos:
         # See https://stackoverflow.com/a/61238571/18829.
         additional_dependencies:
           - ruamel.yaml
-        args: [--messages-only]
+          - setuptools # ModuleNotFoundError: No module named 'pkg_resources'
+        args:
+          - --messages-only
+          - --doc-warnings
+          #- --without-tool=pylint # If you get "pylint: astroid-error ..."
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.6
     hooks:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ require version updates.
   - [As a `pre-commit` hook](#as-a-pre-commit-hook)
 - [Pre-commit hook](#pre-commit-hook)
   - [Using with other pre-commit checks](#using-with-other-pre-commit-checks)
+- [Reliabot script](#reliabot-script)
+  - [Options](#options)
 - [FAQ](#faq)
   - [Does Reliabot work with Renovate?](#does-reliabot-work-with-renovate)
   - [Can you install Reliabot with Homebrew?](#can-you-install-reliabot-with-homebrew)
@@ -117,12 +119,17 @@ You can improve the reliability and performance of Reliabot with Python RE2
 regex support in its environment. This also requires the C++ RE2 library
 (`brew install re2` or use Linux/BSD package tools to install `re2`).
 
+> ⚠ The `pyre2-wheels` extra (which depends on [pyre2-updated][7]) doesn't work
+> for Python 3.12 – it only supports Python 3.6 to 3.11. If you need Python
+> 3.12 you can use the `--re` option to disable warnings about failure to load
+> `re2`.
+
 ```shell
 pip3 install 'reliabot[pyre2-wheels]'
 ```
 
-If the `pyre2-wheels` extra (which depends on [pyre2-updated][7]) doesn't work,
-try the original `pyre2` to build from source. This requires a C++ compiler.
+Alternately, you can try the original `pyre2` to build from source. This
+requires a C++ compiler and libraries installed on your system.
 
 ```shell
 pip3 install 'reliabot[pyre2]'
@@ -184,6 +191,18 @@ configuration, and this order provides the best results:
 1. YAML checker
 2. Reliabot
 3. YAML formatter
+
+## Reliabot script
+
+### Options
+
+- `--re` – As the first argument, this option disables any attempt to use RE2,
+  along with error or warning messages when those attempts fail.
+
+- `--self-test`– As the only argument this runs the `doctest` unit tests.
+
+- `--update` – As the only argument, this runs `reliabot` on the current
+  directory, returning exit code 4 if it made any changes to the file.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -129,8 +129,9 @@ Here is the console output from running Reliabot on its own source sub-folder
 to create a new configuration:
 
 ```console
-reliabot$ rm -f reliabot/.github && mkdir -p reliabot/.github
-reliabot$ ./reliabot/reliabot.py reliabot
+reliabot$ rm -fr reliabot/.github && mkdir -p reliabot/.github reliabot/.git
+
+reliabot$ ./reliabot/reliabot.py reliabot 2>&1
 Creating 'reliabot/.github/dependabot.yml'...
 reliabot$ cat reliabot/.github/dependabot.yml
 ---
@@ -146,22 +147,24 @@ Here is the console output from running Reliabot to update an existing
 configuration in its own source sub-folder (copied from the root folder):
 
 ```console
-reliabot$ rm -f reliabot/.github && mkdir -p reliabot/.github
+reliabot$ rm -fr reliabot/.github && mkdir -p reliabot/.github reliabot/.git
+
 reliabot$ grep -v keep= .github/dependabot.yml >reliabot/.github/dependabot.yml
-reliabot$ ./reliabot/reliabot.py reliabot
+
+reliabot$ ./reliabot/reliabot.py reliabot 2>&1
 Removed obsolete 'github-actions' entry in '/'
 Updating 'reliabot/.github/dependabot.yml'...
-reliabot$ cat reliabot/.github/dependabot.yml
----
-# reliabot: mapping=4 offset=2 sequence=4
-# reliabot: ignore=./reliabot # already tracked in repository root
-# reliabot: ignore=testdir/
-version: 2
-updates:
-  - directory: /
-    package-ecosystem: pip
-    schedule:
-        interval: daily
+reliabot$ cat -n reliabot/.github/dependabot.yml
+ 1	---
+ 2	# reliabot: mapping=4 offset=2 sequence=4
+ 3	# reliabot: ignore=./reliabot # already tracked in repository root
+ 4	# reliabot: ignore=testdir/
+ 5	version: 2
+ 6	updates:
+ 7	  - directory: /
+ 8	    package-ecosystem: pip
+ 9	    schedule:
+ 10	        interval: daily
 ```
 
 ## Pre-commit hook

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ require version updates.
 
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=3 --minlevel=2 -->
 
+- [Usage](#usage)
+  - [Examples](#examples)
 - [Installation](#installation)
   - [From PyPI for direct use](#from-pypi-for-direct-use)
   - [As a `pre-commit` hook](#as-a-pre-commit-hook)
-- [Console script](#console-script)
-  - [Examples](#examples)
 - [Pre-commit hook](#pre-commit-hook)
   - [Using with other pre-commit checks](#using-with-other-pre-commit-checks)
 - [FAQ](#faq)
@@ -49,6 +49,56 @@ You can run Reliabot directly to create a `dependabot.yml` configuration file
 for your GitHub repository, but it's most convenient to run the reliabot hook
 from the [pre‑commit][5] framework, or optionally, with the [pre-commit.ci][6]
 continuous integration service.
+
+## Usage
+
+The `reliabot` script takes one argument: a Git repository path, and creates or
+updates the `dependabot.yml` configuration file for the repository based on the
+files tracked in Git, including both committed and staged files.
+
+### Examples
+
+Here is the console output from running Reliabot on its own source sub-folder
+to create a new configuration:
+
+```console
+reliabot$ rm -fr reliabot/.github && mkdir -p reliabot/.github reliabot/.git
+
+reliabot$ ./reliabot/reliabot.py reliabot 2>&1
+Creating 'reliabot/.github/dependabot.yml'...
+reliabot$ cat reliabot/.github/dependabot.yml
+---
+version: 2
+updates:
+  - directory: /
+    package-ecosystem: pip
+    schedule:
+        interval: monthly
+```
+
+Here is the console output from running Reliabot to update an existing
+configuration in its own source sub-folder (copied from the root folder):
+
+```console
+reliabot$ rm -fr reliabot/.github && mkdir -p reliabot/.github reliabot/.git
+
+reliabot$ grep -v keep= .github/dependabot.yml >reliabot/.github/dependabot.yml
+
+reliabot$ ./reliabot/reliabot.py reliabot 2>&1
+Removed obsolete 'github-actions' entry in '/'
+Updating 'reliabot/.github/dependabot.yml'...
+reliabot$ cat -n reliabot/.github/dependabot.yml
+ 1	---
+ 2	# reliabot: mapping=4 offset=2 sequence=4
+ 3	# reliabot: ignore=./reliabot # already tracked in repository root
+ 4	# reliabot: ignore=testdir/
+ 5	version: 2
+ 6	updates:
+ 7	  - directory: /
+ 8	    package-ecosystem: pip
+ 9	    schedule:
+ 10	        interval: daily
+```
 
 ## Installation
 
@@ -116,56 +166,6 @@ add the following to the `repos` entry in `.pre‑commit‑config.yaml`
 
 After that, Reliabot runs automatically on any Git commit that involves
 `dependabot.yml` or files where Dependabot could update their dependencies.
-
-## Console script
-
-The `reliabot` script takes a single argument: a Git repository path, and
-creates or updates the `dependabot.yml` configuration file for the repository
-based on the files tracked in Git, including both committed and staged files.
-
-### Examples
-
-Here is the console output from running Reliabot on its own source sub-folder
-to create a new configuration:
-
-```console
-reliabot$ rm -fr reliabot/.github && mkdir -p reliabot/.github reliabot/.git
-
-reliabot$ ./reliabot/reliabot.py reliabot 2>&1
-Creating 'reliabot/.github/dependabot.yml'...
-reliabot$ cat reliabot/.github/dependabot.yml
----
-version: 2
-updates:
-  - directory: /
-    package-ecosystem: pip
-    schedule:
-        interval: monthly
-```
-
-Here is the console output from running Reliabot to update an existing
-configuration in its own source sub-folder (copied from the root folder):
-
-```console
-reliabot$ rm -fr reliabot/.github && mkdir -p reliabot/.github reliabot/.git
-
-reliabot$ grep -v keep= .github/dependabot.yml >reliabot/.github/dependabot.yml
-
-reliabot$ ./reliabot/reliabot.py reliabot 2>&1
-Removed obsolete 'github-actions' entry in '/'
-Updating 'reliabot/.github/dependabot.yml'...
-reliabot$ cat -n reliabot/.github/dependabot.yml
- 1	---
- 2	# reliabot: mapping=4 offset=2 sequence=4
- 3	# reliabot: ignore=./reliabot # already tracked in repository root
- 4	# reliabot: ignore=testdir/
- 5	version: 2
- 6	updates:
- 7	  - directory: /
- 8	    package-ecosystem: pip
- 9	    schedule:
- 10	        interval: daily
-```
 
 ## Pre-commit hook
 

--- a/reliabot/reliabot.py
+++ b/reliabot/reliabot.py
@@ -70,20 +70,21 @@ def usage() -> None:
     sys.exit(int(Err.USAGE))
 
 
-def error(message: str) -> None:
+def error(message: str, debug_msg: bool = True) -> None:
     """Report a bug (internal error) in reliabot and exit with status 9.
 
     :param message: Information about the internal error.
+    :param debug_msg: Whether to suggest --self-test for debugging.
     >>> os.environ[DOCTEST_OPT] = ""
     >>> error("testing error reporting")
     Traceback (most recent call last):
     ...
     SystemExit: 9
-    >>> del os.environ[DOCTEST_OPT]
     """
     dedup_warn(f"Internal error - {message}")
     if DOCTEST_OPT in os.environ or sys.argv[len(sys.argv) - 1] != DOCTEST_OPT:
-        print(f"  Diagnose with {sys.argv[0]} {DOCTEST_OPT}", file=sys.stderr)
+        if debug_msg:
+            print(f"Debug with {sys.argv[0]} {DOCTEST_OPT}", file=sys.stderr)
         sys.exit(int(Err.INTERNAL))
 
 
@@ -104,11 +105,12 @@ def dedup_warn(message: str, key: Optional[str] = None) -> None:
 
 RE2 = False
 RE_OPTION = "--re"
-RE_WARNING = """
+RE_WARNING = f"""
 
   Reliabot works better with the 're2' regular expression package.
   See https://github.com/dupuy/reliabot/#installation for install instructions,
-  or use initial '--re' option to use system 're' and suppress this warning."""
+  or use initial '{RE_OPTION}' option to force system 're' and suppress this.
+"""
 
 if len(sys.argv) > 1 and sys.argv[1] == RE_OPTION:
     sys.argv.pop(1)
@@ -138,13 +140,14 @@ DOCTEST_OPTION_FLAGS = 0  # This is modified in the re.error exception handler.
 
 RUAMEL_YAML_NOT_FOUND_ERROR_MESSAGE = """
 
-    Reliabot requires the ruamel.yaml module to preserve comments in dependabot.yml files.
-    See https://github.com/dupuy/reliabot/#installation for installation instructions."""
+  Reliabot requires ruamel.yaml to preserve comments in dependabot.yml files.
+  See https://github.com/dupuy/reliabot/#installation for install instructions.
+"""
 try:
     # ruamel.yaml preserves comments, PyYAML doesn't.
     from ruamel.yaml import YAML
 except ModuleNotFoundError as module_not_found:
-    error(f"{module_not_found} {RUAMEL_YAML_NOT_FOUND_ERROR_MESSAGE}")
+    error(f"{module_not_found} {RUAMEL_YAML_NOT_FOUND_ERROR_MESSAGE}", False)
 else:
     from ruamel.yaml.comments import CommentedMap
     from ruamel.yaml.comments import CommentedSeq
@@ -225,6 +228,8 @@ GITHUB_WORKFLOWS = join(GITHUB, b"workflows")
 GIT_CMD = "/usr/bin/git"
 GIT_DIR = b".git"
 GIT_LS = [GIT_CMD, "ls-files"]
+
+NLSP = "\n "
 
 OPT_UPDATE = "--update"  # For pre-commit, returning Err.UPDATE on changes.
 OPT_UPDATE_PRE_COMMIT = "--update-pre-commit"  # To update pre-commit configs.
@@ -338,7 +343,7 @@ def main(optargv: Optional[list[str]] = None) -> int:  # noqa: MC0001
         if not filename.startswith(os.pathsep):
             cwd = f" in '{os.getcwd()}'"
         err = f"{os_err.strerror}: '{filename}'{cwd}"
-        dedup_warn(f"Failed to {action} configuration file:\n  {err}")
+        dedup_warn(f"Failed to {action} configuration file:{NLSP}{err}")
         return Err.RUNTIME
     except RuntimeError as rt_err:
         dedup_warn(str(rt_err))
@@ -416,11 +421,11 @@ def extract_settings(
     try:
         comments = [comment.value for comment in config.ca.comment[1]]
     except (AttributeError, IndexError, TypeError):
-        nlsp = "\n "
-        warnings.warn(
-            f"{nlsp} extract_settings() couldn't get comments"
-            f"{nlsp}{traceback.format_exc()}"
-        )
+        if config:
+            warnings.warn(
+                f"{NLSP} extract_settings() couldn't get comments"
+                f"{NLSP}{traceback.format_exc()}"
+            )
         return settings
 
     for comment in comments:
@@ -739,12 +744,12 @@ def validate_dependabot_config(config: Union[CommentedMap, dict]) -> None:
                     break
     except TypeError:
         warnings.warn(f"{traceback.format_exc()}")
-        msg = "uration"
+        msg = ""
     except KeyError as key:
         # pylint: disable=raise-missing-from
         raise ValueError(f"Dependabot configuration missing '{key.args[0]}'")
     if msg is not None:
-        raise ValueError(f"Invalid Dependabot config{msg}")
+        raise ValueError(f"Invalid Dependabot configuration{msg}")
 
 
 def create_dependabot_config(ecosystems: dict[str, set]) -> list[dict]:
@@ -805,7 +810,7 @@ def safe_dump(
                 error(f"Can't re-parse YAML with default settings ({indent})")
             else:
                 err = "YAML (indent?) error:"
-                dedup_warn(f"{err} {indent}:\n{str(parser_err)}")
+                dedup_warn(f"{err} {indent}:{NLSP}{str(parser_err)}")
                 settings = EMITTER_SETTINGS
         else:
             emitter.dump(config, config_stream)
@@ -1156,7 +1161,7 @@ SystemExit: 2
 >>> main(["reliabot", "testdir/badlink"])  # doctest: +ELLIPSIS
 Creating 'testdir/badlink/.github/dependabot.yml'...
 Failed to write configuration file:
-  No such file or directory: 'testdir/badlink/.github/dependabot.yml' in ...
+ No such file or directory: 'testdir/badlink/.github/dependabot.yml' in ...
 <Err.RUNTIME: 1>
 >>> sys.stderr = stderr
 >>> os.unlink(badlink)
@@ -1173,7 +1178,7 @@ Failed to write configuration file:
 ... }
 >>> safe_dump(test_config, bad_defaults, io_string)
 YAML (indent?) error: mapping=2 offset=2 sequence=2:
-while parsing a block collection
+ while parsing a block collection
   in "<file>", line 2, column 3
 expected <block end>, but found '?'
   in "<file>", line 3, column 3

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,8 @@ deps =
     covdefaults
     coverage
     -r reliabot/requirements.txt
+package = wheel
+wheel_build_env = .pkg
 
 [testenv:pre-commit]
 commands = pre-commit run --all-files --show-diff-on-failure
@@ -39,8 +41,32 @@ deps =
     -r reliabot/requirements.txt
 skip_install = true
 
+[testenv:doctest-cli]
+allowlist_externals = git, rmdir, sh
+basepython = py311  # pyre2-updated==0.3.7 does not have wheels for Python 3.12
+commands =
+    sh -c "for mdtest in $(grep -l '^```console' *.md); do \
+        awk '/^```console/,/^```$/' $mdtest \
+        | sed -e 's/reliabot$ />>> /' -e '/```/d' > $mdtest.sh; \
+        PYTHONWARNINGS=default doctest-cli $mdtest.sh || STATUS=$?; \
+        rm $mdtest.sh; done; exit $STATUS"
+    rmdir reliabot/.git
+    git restore reliabot/.github
+deps =
+    doctest-cli
+    pyre2-updated
+    -r reliabot/requirements.txt
+ignore_base_python_conflict = False
+
 [tox:tox]
 envlist =
+    doctest-cli
     pre-commit
+    py310
     py311
+    # py312  # can't support re2: pyre2-updated=0.3.7 only goes to 3.11
     py38
+    py39
+labels =
+     test = py310, py311, py38, py39
+     static = doctest-cli, pre-commit

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,15 +1,26 @@
 # Python package options and metadata are configured in `pyproject.toml`;
-# this is only used to configure test and coverage tools.
+# this only configures test and coverage tools, and linters that don't do TOML.
 
 [coverage:run]
 plugins = covdefaults
 
+# TODO: run mypy from prospector using a custom Prospector "strictness" profile.
 [mypy]
 check_untyped_defs = true
 disallow_incomplete_defs = true
 disallow_untyped_defs = true
 warn_redundant_casts = true
 warn_unused_ignores = true
+
+# TODO: make this configuration using a custom Prospector "strictness" profile.
+[pycodestyle]
+# E203 – "Black" style requires a space before a ':' in a list subscript
+# E231 – "missing whitespace after ':'" has false positives on f-strings
+# E241 – "multiple spaces after ','" has false positives on f-strings
+# E272 – "multiple spaces before keyword" has false positives on f-strings
+# W503 – "Black" style enforces W504 instead and splits _before_ binary ops
+ignore = E203, E231, E241, E272, W503
+max-line-length = 99
 
 [testenv]
 commands =


### PR DESCRIPTION
Also fixes
- Reliabot errors and warnings and makes them more consistent
- `No module named 'pkg_resources'` error for prospector
- excessive complexity in `extract_settings()`

and adds more `tox` test configurations.