### PR TITLE
feat: pre-commit hook for tidy numbering and ordering of all Markdown reference links

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -266,6 +266,7 @@ repos:
         language: script
         entry: ./tidy-md-refs.py
         types: [markdown]
+        exclude: tests/
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.17
     hooks:
@@ -282,19 +283,21 @@ repos:
           - mdformat-gfm # GitHub-flavored Markdown
           - mdformat-tables # GitHub-flavored Markdown tables
           - mdformat-toc # generate table of contents
-          - setuptools
-        exclude: styles/
+          - setuptools # ModuleNotFoundError: No module named 'pkg_resources'
+        exclude: styles/|tests/
 
   - repo: https://github.com/markdownlint/markdownlint
     rev: v0.12.0
     hooks:
       - id: markdownlint
         args: [--style=.mdl-style.rb]
+        exclude: tests/
 
   - repo: https://github.com/mineiros-io/pre-commit-hooks
     rev: v0.5.1
     hooks:
       - id: markdown-link-check
+        exclude: tests/
 
   - repo: https://github.com/errata-ai/vale
     rev: v3.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -258,6 +258,14 @@ repos:
           - --without-hashes
 
   # Markdown
+  - repo: local
+    hooks:
+      # Use param, raises, returns and var; use PEP484 annotations for types.
+      - id: tidy-md-refs
+        name: Tidy numbering of Markdown reference links
+        language: script
+        entry: ./tidy-md-refs.py
+        types: [markdown]
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.17
     hooks:

--- a/humans.txt
+++ b/humans.txt
@@ -1,3 +1,4 @@
 /* TEAM */
   Original Author: dupuy (Alexander Dupuy)
   First Contributor: appills
+  Earliest Code Writer: drdrang [tidy-md-refs.py]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ select = [
 ]
 ignore = [
     "ANN101",  # missing-type-self
+    "B028",  # no-explicit-stacklevel
     "D105",  # undocumented-magic-method
     "ISC001",  # single-line-implicit-string-concatenation  # formatter conflict
     "PLR091", # too-manu-*  # TODO: reduce complexity or disable with comments

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,10 +12,22 @@ warn_redundant_casts = true
 warn_unused_ignores = true
 
 [testenv]
+allowlist_externals = cp
+                      git
+                      sh
 commands =
     coverage erase
-    coverage run reliabot/reliabot.py --self-test
-    coverage report --fail-under=85
+    coverage run -a reliabot/reliabot.py --self-test
+    coverage run -a tidy-md-refs.py Makefile README.md
+    git diff --exit-code Makefile README.md
+    cp tests/untidy.md tests/tidied.md
+    sh -c "! coverage run -a tidy-md-refs.py tests/tidied.md"
+    git diff --exit-code tests/tidied.md
+    sh -c "coverage run -a tidy-md-refs.py <tests/untidy.md>tests/tidied.md"
+    git diff --exit-code tests/tidied.md
+    sh -c "! coverage run -a tidy-md-refs.py -<tests/untidy.md>tests/tidied.md"
+    git diff --exit-code tests/tidied.md
+    coverage report --no-skip-covered --fail-under=85
 deps =
     covdefaults
     coverage

--- a/tests/tidied.md
+++ b/tests/tidied.md
@@ -1,0 +1,33 @@
+# Test case for tidy-md-refs.py
+
+- [Ask a question](#asking-a-question) about using Reliabot.
+- [Open an issue][1] about a problem, or for a way to improve Reliabot.
+
+
+
+## Asking a question
+
+> 💡 If you have a Reliabot question, take a look at the [README][2] and its
+> [FAQ][3] to see if it's answered there.
+
+Before asking a question, search for [existing issues][4] that are similar.
+
+- [Create a new issue][5], labeling it as a **question**.
+
+- To see if other users have experienced (and perhaps already solved) your
+  problem, search the [bug tracker][6] for similar issues or errors.
+- Reading the [documentation][2] can help. If you need help, consider just
+  [asking a question][7] first.
+
+
+
+- [Create an issue using the problem template][8]. It may not be clear yet
+  whether it's a bug, so please don't label the issue.
+
+[1]: https://github.com/dupuy/reliabot/issues/new
+[2]: https://spec.commonmark.org/0.31.2/#link-reference-definitions
+[3]: https://github.com/dupuy/reliabot#faq
+[4]: https://github.com/dupuy/reliabot/issues?q=is%3Aissue+sort%3Aupdated-desc
+[5]: https://github.com/dupuy/reliabot/issues/new
+[6]: https://github.com/dupuy/reliabot/issues?q=label%3Abug
+[8]: https://github.com/dupuy/reliabot/issues/new?template=problem.md

--- a/tests/untidy.md
+++ b/tests/untidy.md
@@ -1,0 +1,43 @@
+# Test case for tidy-md-refs.py
+
+- [Ask a question](#asking-a-question) about using Reliabot.
+- [Open an issue][2] about a problem, or for a way to improve Reliabot.
+[44]: unused
+[
+ unused text labels
+]: get-removed "leaving only a newline"
+
+## Asking a question
+
+> 💡 If you have a Reliabot question, take a look at the [README][6] and its
+> [FAQ][7] to see if it's answered there.
+
+Before asking a question, search for [existing issues][
+ 8
+] that are similar.
+
+- [Create a new issue][9], labeling it as a **question**.
+
+- To see if other users have experienced (and perhaps already solved) your
+  problem, search the [bug tracker][10] for similar issues or errors.
+- Reading the [documentation][6] can help. If you need help, consider just
+  [asking a question][1] first.
+
+[3]: [4]:
+
+- [Create an issue using the problem template][13]. It may not be clear yet
+  whether it's a bug, so please don't label the issue.
+
+[1]:
+[2]: https://github.com/dupuy/reliabot/issues/new
+
+[5]:
+[6]: https://spec.commonmark.org/0.31.2/#link-reference-definitions
+[7]:
+https://github.com/dupuy/reliabot#faq
+[
+ 8
+]: https://github.com/dupuy/reliabot/issues?q=is%3Aissue+sort%3Aupdated-desc
+[9]: https://github.com/dupuy/reliabot/issues/new
+[10]: https://github.com/dupuy/reliabot/issues?q=label%3Abug
+[13]: https://github.com/dupuy/reliabot/issues/new?template=problem.md

--- a/tidy-md-refs.py
+++ b/tidy-md-refs.py
@@ -1,8 +1,10 @@
 #!/usr/bin/python3
-"""Read a Markdown file via standard input and tidy its reference links.
+"""Tidy numbering and ordering of all Markdown reference links in FILEs.
 
-The reference links will be numbered in the order they appear in the text and
-placed at the bottom of the file.
+Number _all_ reference links in the order they appear in the text and place
+them at the end of the file.
+
+If no files are given, read stdin and print tidied Markdown to stdout.
 
 Original script by Dr. Drang – https://github.com/drdrang/
 Posted at:
@@ -12,8 +14,11 @@ WayBack machine archive link.
 """
 from __future__ import annotations
 
+import argparse
 import re
 import sys
+from typing import Optional
+from typing import TextIO
 
 # The regex for finding reference links in the text. Don't find
 # footnotes by mistake.
@@ -24,30 +29,89 @@ link = re.compile(r"\[([^\]]+)\]\[([^^\]]+)\]")
 label = re.compile(r"^\[([^^\]]+)\]:\s+(.+)$", re.MULTILINE)
 
 
-def refrepl(m: re.Match) -> str:
-    """Rewrite reference links with the reordered link numbers."""
-    return "[%s][%d]" % (m.group(1), order.index(m.group(2)) + 1)
+def tidy(text: str) -> str:
+    """Find all the links and references in the text and reorder them."""
+
+    def refrepl(m: re.Match) -> str:
+        """Rewrite reference links with the reordered link numbers."""
+        return "[%s][%d]" % (m.group(1), order.index(m.group(2)) + 1)
+
+    links = link.findall(text)
+    if not links:
+        return text
+
+    labels = dict(label.findall(text))
+
+    # Determine the order of the links in the text. If a link is used
+    # more than once, its order is its first position.
+    order: list[str] = []
+    for i in links:
+        if order.count(i[1]) == 0:
+            order.append(i[1])
+
+    # Make a list of the references in order of appearance.
+    newlabels = [
+        "[%d]: %s" % (i + 1, labels[j]) for (i, j) in enumerate(order)
+    ]
+
+    # Remove the old references and put the new ones at the end of the text.
+    text = label.sub("", text).rstrip() + "\n" * 2 + "\n".join(newlabels)
+
+    # Rewrite the links with the new reference numbers.
+    text = link.sub(refrepl, text) + "\n"
+
+    return text
 
 
-# Read in the file and find all the links and references.
-text = sys.stdin.read()
-links = link.findall(text)
-labels = dict(label.findall(text))
+def tidy_file(input_file: TextIO, output_file: Optional[TextIO]) -> bool:
+    """Tidy a file, returning True if the output is identical."""
+    original = input_file.read()
+    tidied = tidy(original)
+    if output_file is None:
+        if original == tidied:
+            return True
+        input_file.seek(0)
+        output_file = input_file
+    print(tidied, end="", file=output_file)
+    if output_file == input_file:
+        output_file.truncate()
+    return original == tidied
 
-# Determine the order of the links in the text. If a link is used
-# more than once, its order is its first position.
-order: list[str] = []
-for i in links:
-    if order.count(i[1]) == 0:
-        order.append(i[1])
 
-# Make a list of the references in order of appearance.
-newlabels = ["[%d]: %s" % (i + 1, labels[j]) for (i, j) in enumerate(order)]
+def main() -> int:
+    """Tidy Markdown file arguments' reference links, or stdin if no files."""
+    docstring = sys.modules[__name__].__doc__ or ""
+    description = docstring.split("\n", 1)[0]
+    epilog = """
+    Returns exit code 1 if any files were modified, 2 for bad arguments, and
+    zero (success) if all files were already tidy.
 
-# Remove the old references and put the new ones at the end of the text.
-text = label.sub("", text).rstrip() + "\n" * 3 + "\n".join(newlabels)
+    If no FILE arguments are present, reads stdin and writes stdout, always
+    returning success, even if input was not tidy. To get exit code 1 for untidy
+    stdin, provide '-' as the filename."""
+    parser = argparse.ArgumentParser(
+        description=description, epilog=epilog, allow_abbrev=False
+    )
+    parser.add_argument(
+        "files",
+        help="(multiple) Markdown file(s) for reference link tidying",
+        metavar="FILE",
+        nargs="*",
+        type=argparse.FileType("r+"),
+    )
+    args = parser.parse_args()
+    if not args.files:
+        tidy_file(sys.stdin, sys.stdout)
+        return 0
+    modified = False
+    for in_file in args.files:
+        out_file = None
+        if in_file == sys.stdin:
+            out_file = sys.stdout
+        if not tidy_file(in_file, out_file):
+            modified = True
+    return 1 if modified else 0
 
-# Rewrite the links with the new reference numbers.
-text = link.sub(refrepl, text)
 
-print(text)
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tidy-md-refs.py
+++ b/tidy-md-refs.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python
+
+import sys
+import re
+
+'''Read a Markdown file via standard input and tidy its
+reference links. The reference links will be numbered in
+the order they appear in the text and placed at the bottom
+of the file.'''
+
+# The regex for finding reference links in the text. Don't find
+# footnotes by mistake.
+link = re.compile(r'\[([^\]]+)\]\[([^^\]]+)\]')
+
+# The regex for finding the label. Again, don't find footnotes
+# by mistake.
+label = re.compile(r'^\[([^^\]]+)\]:\s+(.+)$', re.MULTILINE)
+
+def refrepl(m):
+  'Rewrite reference links with the reordered link numbers.'
+  return '[%s][%d]' % (m.group(1), order.index(m.group(2)) + 1)
+
+# Read in the file and find all the links and references.
+text = sys.stdin.read()
+links = link.findall(text)
+labels = dict(label.findall(text))
+
+# Determine the order of the links in the text. If a link is used
+# more than once, its order is its first position.
+order = []
+for i in links:
+  if order.count(i[1]) == 0:
+    order.append(i[1])
+
+# Make a list of the references in order of appearance.
+newlabels = [ '[%d]: %s' % (i + 1, labels[j]) for (i, j) in enumerate(order) ]
+
+# Remove the old references and put the new ones at the end of the text.
+text = label.sub('', text).rstrip() + '\n'*3 + '\n'.join(newlabels)
+
+# Rewrite the links with the new reference numbers.
+text = link.sub(refrepl, text)
+
+print text

--- a/tidy-md-refs.py
+++ b/tidy-md-refs.py
@@ -1,24 +1,33 @@
-#!/usr/bin/python
+#!/usr/bin/python3
+"""Read a Markdown file via standard input and tidy its reference links.
 
-import sys
+The reference links will be numbered in the order they appear in the text and
+placed at the bottom of the file.
+
+Original script by Dr. Drang – https://github.com/drdrang/
+Posted at:
+https://leancrew.com/all-this/2012/09/tidying-markdown-reference-links/ or
+https://web.archive.org/web/20120920012828/http://www.leancrew.com/all-this/
+WayBack machine archive link.
+"""
+from __future__ import annotations
+
 import re
-
-'''Read a Markdown file via standard input and tidy its
-reference links. The reference links will be numbered in
-the order they appear in the text and placed at the bottom
-of the file.'''
+import sys
 
 # The regex for finding reference links in the text. Don't find
 # footnotes by mistake.
-link = re.compile(r'\[([^\]]+)\]\[([^^\]]+)\]')
+link = re.compile(r"\[([^\]]+)\]\[([^^\]]+)\]")
 
 # The regex for finding the label. Again, don't find footnotes
 # by mistake.
-label = re.compile(r'^\[([^^\]]+)\]:\s+(.+)$', re.MULTILINE)
+label = re.compile(r"^\[([^^\]]+)\]:\s+(.+)$", re.MULTILINE)
 
-def refrepl(m):
-  'Rewrite reference links with the reordered link numbers.'
-  return '[%s][%d]' % (m.group(1), order.index(m.group(2)) + 1)
+
+def refrepl(m: re.Match) -> str:
+    """Rewrite reference links with the reordered link numbers."""
+    return "[%s][%d]" % (m.group(1), order.index(m.group(2)) + 1)
+
 
 # Read in the file and find all the links and references.
 text = sys.stdin.read()
@@ -27,18 +36,18 @@ labels = dict(label.findall(text))
 
 # Determine the order of the links in the text. If a link is used
 # more than once, its order is its first position.
-order = []
+order: list[str] = []
 for i in links:
-  if order.count(i[1]) == 0:
-    order.append(i[1])
+    if order.count(i[1]) == 0:
+        order.append(i[1])
 
 # Make a list of the references in order of appearance.
-newlabels = [ '[%d]: %s' % (i + 1, labels[j]) for (i, j) in enumerate(order) ]
+newlabels = ["[%d]: %s" % (i + 1, labels[j]) for (i, j) in enumerate(order)]
 
 # Remove the old references and put the new ones at the end of the text.
-text = label.sub('', text).rstrip() + '\n'*3 + '\n'.join(newlabels)
+text = label.sub("", text).rstrip() + "\n" * 3 + "\n".join(newlabels)
 
 # Rewrite the links with the new reference numbers.
 text = link.sub(refrepl, text)
 
-print text
+print(text)

--- a/tidy-md-refs.py
+++ b/tidy-md-refs.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+# pylint: disable=invalid-name
 """Tidy numbering and ordering of all Markdown reference links in FILEs.
 
 Number _all_ reference links in the order they appear in the text and place
@@ -58,7 +59,7 @@ def tidy(text: str) -> str:
 
     def refrepl(m: re.Match) -> str:
         """Rewrite reference links with the reordered link numbers."""
-        return "[%s][%d]" % (m.group(1), order.index(m.group(2)) + 1)
+        return f"[{m.group(1)}][{order.index(m.group(2)) + 1}]"
 
     links = link.findall(text)
     if not links:
@@ -78,7 +79,8 @@ def tidy(text: str) -> str:
     for i, j in enumerate(order):
         try:
             newlabels.append(f"[{i + 1}]: {labels[j]}")
-        except KeyError:
+        except KeyError:  # noqa: PERF203
+            # Warn about missing label, but continue processing others.
             missing_ref = (
                 f"Missing/empty reference [{i + 1}] (originally [{j}])"
             )
@@ -90,7 +92,7 @@ def tidy(text: str) -> str:
     # Remove any leftover invalid numeric labels that may conflict or confuse.
     badlabels = [lab.replace("\n", "␤") for lab in badlabel.findall(text)]
     if badlabels:
-        bad_labels = "\n  • ".join(["Removed invalid references:"] + badlabels)
+        bad_labels = "\n  • ".join(["Removed invalid references:", *badlabels])
         warnings.warn(bad_labels)
         text = badlabel.sub("", text).rstrip()
 
@@ -98,9 +100,7 @@ def tidy(text: str) -> str:
     text += "\n" * 2 + "\n".join(newlabels)
 
     # Rewrite the links with the new reference numbers.
-    text = link.sub(refrepl, text) + "\n"
-
-    return text
+    return link.sub(refrepl, text) + "\n"
 
 
 def tidy_file(input_file: TextIO, output_file: Optional[TextIO]) -> bool:


### PR DESCRIPTION
Number _all_ reference links in the order they appear in the text and place
them at the end of the file.

If no files are given, read stdin and print tidied Markdown to stdout.

Original script by Dr. Drang – https://github.com/drdrang/ @drdrang
Posted at:
https://leancrew.com/all-this/2012/09/tidying-markdown-reference-links/ or
https://web.archive.org/web/20120920012828/http://www.leancrew.com/all-this/
WayBack machine archive link.
