### PR TITLE
fix: codeql.yaml cron error

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -12,7 +12,7 @@ on:
     # The branches below must be a subset of the branches above
     branches: ['main']
   schedule:
-    - cron: 47 2 * * 1'
+    - cron: '47 2 * * 1'
 
 # Declare default permissions as read only.
 permissions:
@@ -52,18 +52,9 @@ jobs:
 
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@8a470fddafa5cbb6266ee11b37ef4d8aae19c571 # v3.24.6
-
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-      #   If the Autobuild fails above, remove it and uncomment the following three lines.
-      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-      # - run: |
-      #   echo "Run, Build Application using script"
-      #   ./location_of_script_within_repo/buildscript.sh
+      # [This is commented out since there are no compiled languages]
+      # - name: Autobuild
+      #   uses: github/codeql-action/autobuild@v3
 
       - name: 'Perform CodeQL analysis'
         uses: github/codeql-action/analyze@8a470fddafa5cbb6266ee11b37ef4d8aae19c571 # v3.24.6


### PR DESCRIPTION
- fix: missing quote for cron configuration
- chore: comment out useless Autobuild step, remove extra comments