### PR TITLE
chore: dependabot noise, broken badge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,4 +12,4 @@ updates:
   - directory: /
     package-ecosystem: github-actions
     schedule:
-      interval: daily
+      interval: monthly

--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@
 [![GitHub License](https://img.shields.io/github/license/dupuy/reliabot)](LICENSE)
 ![GitHub repository size](https://img.shields.io/github/repo-size/dupuy/reliabot)
 ![GitHub repository file+folder count](https://img.shields.io/github/directory-file-count/dupuy/reliabot)
-![Lines of code](https://tokei.rs/b1/github/dupuy/reliabot)
+
+<!-- ![Lines of code](https://img.shields.io/tokei/lines/github/dupuy/reliabot) -->
+
+<!-- ![Lines of code](https://tokei.rs/b1/github/dupuy/reliabot) -->
+
 ![GitHub top language](https://img.shields.io/github/languages/top/dupuy/reliabot)
 
 [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/dupuy/reliabot.svg)](http://isitmaintained.com/project/dupuy/reliabot "Average time to resolve an issue")


### PR DESCRIPTION
- **docs: disable broken badge**
- **chore: reduce dependabot activity for GitHub actions**
