### PR TITLE
feat: group GitHub Actions infrastructure dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,10 @@ updates:
     package-ecosystem: github-actions
     schedule:
       interval: monthly
+    groups:
+      gh-actions-infrastructure:
+        patterns:
+          - 'actions/*'
+          - 'github/codeql-action/*'
+          - 'ossf/*'
+          - 'step-security/*'


### PR DESCRIPTION
This should avoid long chains of Dependabot updates to GitHub actions
where every PR needs to be rebased after merging previous ones.