### PR TITLE
feat: group GitHub Actions release dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,8 @@ updates:
           - 'github/codeql-action/*'
           - 'ossf/*'
           - 'step-security/*'
+      gh-actions-releases:
+        patterns:
+          - 'ncipollo/release-action'
+          - 'orhun/git-cliff-action'
+          - 'pypa/*'


### PR DESCRIPTION
This should avoid chains of Dependabot updates to GitHub actions where every PR needs to be rebased after merging previous ones.