### PR TITLE
refactor: for updated Ruff checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -175,7 +175,7 @@ repos:
 
   # Python
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.8
+    rev: v0.12.2
     hooks:
       # Run the linter.
       - id: ruff

--- a/reliabot/reliabot.py
+++ b/reliabot/reliabot.py
@@ -1053,7 +1053,7 @@ def self_test() -> int:
         os.environ["PYTHONWARNINGS"] = "default"  # Also affect subprocesses
 
     # pylint: disable=import-outside-toplevel,redefined-outer-name
-    import doctest
+    import doctest  # noqa: PLC0415
 
     flags = DOCTEST_OPTION_FLAGS
     mod = None

--- a/tidy-md-refs.py
+++ b/tidy-md-refs.py
@@ -38,7 +38,6 @@ import argparse
 import re
 import sys
 import warnings
-from typing import Optional
 from typing import TextIO
 
 # The regex for finding reference links in the text. Don't find
@@ -104,7 +103,7 @@ def tidy(text: str) -> str:
     return link.sub(refrepl, text) + "\n"
 
 
-def tidy_file(input_file: TextIO, output_file: Optional[TextIO]) -> bool:
+def tidy_file(input_file: TextIO, output_file: TextIO | None = None) -> bool:
     """Tidy a file, returning True if the output is identical."""
     original = input_file.read()
     tidied = tidy(original)


### PR DESCRIPTION
Ruff is adding more Pylint checks, but requires its own suppressions.

- fix: suppress Ruff error in self_test
- refactor: Optional[X] -> X | None
  Also in tidy-md-refs.py, for #208
