### PR TITLE
fix: python build GHA hardening

### DIFF
--- a/.github/workflows/python-app.yaml
+++ b/.github/workflows/python-app.yaml
@@ -232,6 +232,7 @@ jobs:
             github.com:443
             objects.githubusercontent.com:443
             pypi.org:443
+            release-assets.githubusercontent.com:443
 
       - name: 'Checkout repository'
         if: env.pr-commit == 'true'


### PR DESCRIPTION
GitHub now downloads releases from release-assets.githubuser...