### PR TITLE
fix: allow release-assets.githubusercontent.com for CodeQL

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -42,6 +42,7 @@ jobs:
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             uploads.github.com:443
 
       - name: 'Checkout repository'


### PR DESCRIPTION
Only needed if the runner for CodeQL doesn't have the latest version,
causing intermittent failures.