### PR TITLE
chore(release): reliabot v0.3.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -307,7 +307,7 @@ repos:
     rev: v3.14.1
     hooks:
       - id: vale
-        exclude: LICENSE|humans\.txt|requirements.*|styles/
+        exclude: CHANGELOG*|LICENSE|humans\.txt|requirements.*|styles/
         types_or:
           - asciidoc
           - html

--- a/docs/CHANGELOG-0.md
+++ b/docs/CHANGELOG-0.md
@@ -6,6 +6,74 @@ It uses the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format,
 and follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) for
 releases.
 
+## [0.3.2] - 2026-04-07
+### Details
+
+#### Added 🚀
+- Add Codacy coverage badge by @dupuyarc in [#308](https://github.com/dupuy/reliabot/pull/308)
+- Add codacy coverage reporter by @dupuyarc in [#302](https://github.com/dupuy/reliabot/pull/302)
+- Add Makefile target to copy corpus files by @dupuyarc
+- Update for tests with new Python versions by @dupuyarc in [#276](https://github.com/dupuy/reliabot/pull/276)
+
+#### Changed 🔄
+- Disable pre-commit.ci autoupdate by @dupuyarc in [#326](https://github.com/dupuy/reliabot/pull/326)
+- Ruff 0.15.4 update by @dupuyarc in [#315](https://github.com/dupuy/reliabot/pull/315)
+- * chore(deps-dev): bump ruff from 0.15.2 to 0.15.4 by @dupuyarc in [#315](https://github.com/dupuy/reliabot/pull/315)
+- Bumps [ruff](https://github.com/astral-sh/ruff) from 0.15.2 to 0.15.4. by @dupuyarc in [#315](https://github.com/dupuy/reliabot/pull/315)
+-  by @dupuyarc in [#315](https://github.com/dupuy/reliabot/pull/315)
+- Updated-dependencies: by @dupuyarc in [#315](https://github.com/dupuy/reliabot/pull/315)
+-  by @dupuyarc in [#315](https://github.com/dupuy/reliabot/pull/315)
+- dependency-version: 0.15.4 by @dupuyarc in [#315](https://github.com/dupuy/reliabot/pull/315)
+- dependency-type: direct:development by @dupuyarc in [#315](https://github.com/dupuy/reliabot/pull/315)
+- update-type: version-update:semver-patch by @dupuyarc in [#315](https://github.com/dupuy/reliabot/pull/315)
+- ... by @dupuyarc in [#315](https://github.com/dupuy/reliabot/pull/315)
+- Dependabot[bot] <support@github.com> by @dupuyarc in [#315](https://github.com/dupuy/reliabot/pull/315)
+- * chore: pre-commit-update by @dupuyarc in [#315](https://github.com/dupuy/reliabot/pull/315)
+-  by @dupuyarc in [#315](https://github.com/dupuy/reliabot/pull/315)
+- Dependabot[bot] <support@github.com> by @dupuyarc in [#315](https://github.com/dupuy/reliabot/pull/315)
+- Dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com> by @dupuyarc in [#315](https://github.com/dupuy/reliabot/pull/315)
+- Only run Codacy coverage for main repo by @dupuyarc in [#309](https://github.com/dupuy/reliabot/pull/309)
+- Port address by @dupuyarc in [#307](https://github.com/dupuy/reliabot/pull/307)
+- Wrap up coverage reporter by @dupuyarc in [#304](https://github.com/dupuy/reliabot/pull/304)
+- Write` is not needed to upload artificts by @dupuyarc
+- Add codacy coverage reporter by @dupuyarc in [#302](https://github.com/dupuy/reliabot/pull/302)
+- Add Makefile target to copy corpus files by @dupuyarc
+- Update pre-commit on PyPI updates by @dupuyarc
+- Switch to repository rules for branch protection by @dupuyarc in [#292](https://github.com/dupuy/reliabot/pull/292)
+- Condense and augment badges in README.md by @dupuyarc in [#290](https://github.com/dupuy/reliabot/pull/290)
+- Pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com> by @dupuyarc in [#290](https://github.com/dupuy/reliabot/pull/290)
+- Align dependabot.yml indent settings with prettier by @dupuyarc in [#289](https://github.com/dupuy/reliabot/pull/289)
+- Try to get the python-app workflow going again by @dupuyarc in [#286](https://github.com/dupuy/reliabot/pull/286)
+- Multi-arch build with pinned hashes for Docker by @dupuyarc in [#282](https://github.com/dupuy/reliabot/pull/282)
+- Multi-architecture Dockerfile (ARM64 & AMD64) by @dupuyarc in [#279](https://github.com/dupuy/reliabot/pull/279)
+- Update for tests with new Python versions by @dupuyarc in [#276](https://github.com/dupuy/reliabot/pull/276)
+- Provide a corpus and fuzzer dictionary for Atheris fuzzing by @dupuyarc in [#275](https://github.com/dupuy/reliabot/pull/275)
+- Handle ValueError from ruamel.yaml by @dupuyarc in [#272](https://github.com/dupuy/reliabot/pull/272)
+- Really add pre-commit-update check by @dupuyarc in [#268](https://github.com/dupuy/reliabot/pull/268)
+- Pin Docker base image and apt pkgs by @dupuyarc in [#266](https://github.com/dupuy/reliabot/pull/266)
+- Pre-commit-update by @dupuyarc in [#265](https://github.com/dupuy/reliabot/pull/265)
+- Atheris fuzzing by @dupuyarc in [#261](https://github.com/dupuy/reliabot/pull/261)
+
+#### Fixed 🛠
+- Disable pre-commit.ci autoupdate by @dupuyarc in [#326](https://github.com/dupuy/reliabot/pull/326)
+- Only run Codacy coverage for main repo by @dupuyarc in [#309](https://github.com/dupuy/reliabot/pull/309)
+- Port address by @dupuyarc in [#307](https://github.com/dupuy/reliabot/pull/307)
+- Extra egress for coverage by @dupuyarc in [#306](https://github.com/dupuy/reliabot/pull/306)
+- Run fuzzer as non-root in container by @dupuyarc in [#305](https://github.com/dupuy/reliabot/pull/305)
+- GH Actions schema warning by @dupuyarc in [#303](https://github.com/dupuy/reliabot/pull/303)
+- Generate coverage XML data with tox by @dupuyarc
+- Token permission errors by @dupuyarc
+- Align dependabot.yml indent settings with prettier by @dupuyarc in [#289](https://github.com/dupuy/reliabot/pull/289)
+- Try to get the python-app workflow going again by @dupuyarc in [#286](https://github.com/dupuy/reliabot/pull/286)
+- Update for tests with new Python versions by @dupuyarc in [#276](https://github.com/dupuy/reliabot/pull/276)
+- Handle ValueError from ruamel.yaml by @dupuyarc in [#272](https://github.com/dupuy/reliabot/pull/272)
+- Handle NotImplementedError from ruamel.yaml by @dupuyarc in [#271](https://github.com/dupuy/reliabot/pull/271)
+- Pin Docker base image and apt pkgs by @dupuyarc in [#266](https://github.com/dupuy/reliabot/pull/266)
+
+[0.3.2]: https://github.com/dupuy/reliabot/compare/v0.3.0..v0.3.2
+
+<!-- generated by git-cliff on 2026-04-07 -->
+
 ## [0.3.0] - 2026-01-02
 
 ### Details
@@ -479,3 +547,4 @@ releases.
 [0.2.4]: https://github.com/dupuy/reliabot/compare/v0.2.2..v0.2.4
 [0.2.5]: https://github.com/dupuy/reliabot/compare/v0.2.4..v0.2.5
 [0.3.0]: https://github.com/dupuy/reliabot/compare/v0.2.5..v0.3.0
+[0.3.2]: https://github.com/dupuy/reliabot/compare/v0.3.0..v0.3.2

--- a/markdown-link-check.sh
+++ b/markdown-link-check.sh
@@ -33,6 +33,11 @@ cat >"$TMP_CONFIG" <<EOF
       }
     }
   ],
+  "ignorePatterns": [
+    {
+      "pattern": "^mailto:"
+    }
+  ],
   "replacementPatterns": [
     {
       "pattern": "^/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,9 +92,12 @@ split_commits = true
 commit_preprocessors = [
     # remove issue numbers from commits
     { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "" },
+    { pattern = "^-.*$", replace = "" },
 ]
 # regex for parsing and grouping commits
 commit_parsers = [
+    { message = "^chore", scope = "deps", skip = "true" },
+    { scope = "deps-dev", skip = "true" },
     { message = "^.*: add", group = "Added 🚀" },
     { message = "^.*: support", group = "Added 🚀" },
     { message = "^.*: remove", group = "Removed 🗑️" },
@@ -119,7 +122,7 @@ sort_commits = "newest"
 
 [tool.poetry]
 name = "reliabot"
-version = "0.3.0"
+version = "0.3.2"
 description = "Maintain GitHub Dependabot configuration."
 license = "MIT"
 authors = ["Alexander Dupuy <alex@dupuy.us>"]


### PR DESCRIPTION
- **ruff 0.15.4 update (#315)**
  * chore(deps-dev): bump ruff from 0.15.2 to 0.15.4
  
  Bumps [ruff](https://github.com/astral-sh/ruff) from 0.15.2 to 0.15.4.
  - [Release notes](https://github.com/astral-sh/ruff/releases)
  - [Changelog](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md)
  - [Commits](https://github.com/astral-sh/ruff/compare/0.15.2...0.15.4)
  
  ---
  updated-dependencies:
  - dependency-name: ruff
    dependency-version: 0.15.4
    dependency-type: direct:development
    update-type: version-update:semver-patch
  ...
  
  Signed-off-by: dependabot[bot] <support@github.com>
  
  * chore: pre-commit-update
  
  ---------
  
  Signed-off-by: dependabot[bot] <support@github.com>
  Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

- **chore(deps): bump github/codeql-action from 4.32.4 to 4.35.1 (#323)**
  Bumps [github/codeql-action](https://github.com/github/codeql-action) from 4.32.4 to 4.35.1.
  - [Release notes](https://github.com/github/codeql-action/releases)
  - [Changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md)
  - [Commits](https://github.com/github/codeql-action/compare/89a39a4e59826350b863aa6b6252a07ad50cf83e...c10b8064de6f491fea524254123dbe5e09572f13)
  
  ---
  updated-dependencies:
  - dependency-name: github/codeql-action
    dependency-version: 4.35.1
    dependency-type: direct:production
    update-type: version-update:semver-minor
  ...
  
  Signed-off-by: dependabot[bot] <support@github.com>
  Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

- **chore(deps-dev): bump ruff from 0.15.4 to 0.15.8 (#322)**
  Bumps [ruff](https://github.com/astral-sh/ruff) from 0.15.4 to 0.15.8.
  - [Release notes](https://github.com/astral-sh/ruff/releases)
  - [Changelog](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md)
  - [Commits](https://github.com/astral-sh/ruff/compare/0.15.4...0.15.8)
  
  ---
  updated-dependencies:
  - dependency-name: ruff
    dependency-version: 0.15.8
    dependency-type: direct:development
    update-type: version-update:semver-patch
  ...
  
  Signed-off-by: dependabot[bot] <support@github.com>
  Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

- **chore(deps): bump the gh-actions-infrastructure group across 1 directory with 3 updates (#320)**
  chore(deps): bump the gh-actions-infrastructure group with 3 updates
  
  Bumps the gh-actions-infrastructure group with 3 updates: [step-security/harden-runner](https://github.com/step-security/harden-runner), [actions/dependency-review-action](https://github.com/actions/dependency-review-action) and [actions/download-artifact](https://github.com/actions/download-artifact).
  
  
  Updates `step-security/harden-runner` from 2.15.0 to 2.16.1
  - [Release notes](https://github.com/step-security/harden-runner/releases)
  - [Commits](https://github.com/step-security/harden-runner/compare/a90bcbc6539c36a85cdfeb73f7e2f433735f215b...fe104658747b27e96e4f7e80cd0a94068e53901d)
  
  Updates `actions/dependency-review-action` from 4.8.3 to 4.9.0
  - [Release notes](https://github.com/actions/dependency-review-action/releases)
  - [Commits](https://github.com/actions/dependency-review-action/compare/05fe4576374b728f0c523d6a13d64c25081e0803...2031cfc080254a8a887f58cffee85186f0e49e48)
  
  Updates `actions/download-artifact` from 8.0.0 to 8.0.1
  - [Release notes](https://github.com/actions/download-artifact/releases)
  - [Commits](https://github.com/actions/download-artifact/compare/70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3...3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c)
  
  ---
  updated-dependencies:
  - dependency-name: step-security/harden-runner
    dependency-version: 2.16.1
    dependency-type: direct:production
    update-type: version-update:semver-minor
    dependency-group: gh-actions-infrastructure
  - dependency-name: actions/dependency-review-action
    dependency-version: 4.9.0
    dependency-type: direct:production
    update-type: version-update:semver-minor
    dependency-group: gh-actions-infrastructure
  - dependency-name: actions/download-artifact
    dependency-version: 8.0.1
    dependency-type: direct:production
    update-type: version-update:semver-patch
    dependency-group: gh-actions-infrastructure
  ...
  
  Signed-off-by: dependabot[bot] <support@github.com>
  Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

- **chore(deps-dev): bump tox from 4.46.3 to 4.52.0 (#319)**
  Bumps [tox](https://github.com/tox-dev/tox) from 4.46.3 to 4.52.0.
  - [Release notes](https://github.com/tox-dev/tox/releases)
  - [Changelog](https://github.com/tox-dev/tox/blob/main/docs/changelog.rst)
  - [Commits](https://github.com/tox-dev/tox/compare/4.46.3...4.52.0)
  
  ---
  updated-dependencies:
  - dependency-name: tox
    dependency-version: 4.52.0
    dependency-type: direct:development
    update-type: version-update:semver-minor
  ...
  
  Signed-off-by: dependabot[bot] <support@github.com>
  Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

- **chore(deps): bump ncipollo/release-action from 1.20.0 to 1.21.0 in the gh-actions-releases group across 1 directory (#321)**
  chore(deps): bump ncipollo/release-action
  
  Bumps the gh-actions-releases group with 1 update: [ncipollo/release-action](https://github.com/ncipollo/release-action).
  
  
  Updates `ncipollo/release-action` from 1.20.0 to 1.21.0
  - [Release notes](https://github.com/ncipollo/release-action/releases)
  - [Commits](https://github.com/ncipollo/release-action/compare/b7eabc95ff50cbeeedec83973935c8f306dfcd0b...339a81892b84b4eeb0f6e744e4574d79d0d9b8dd)
  
  ---
  updated-dependencies:
  - dependency-name: ncipollo/release-action
    dependency-version: 1.21.0
    dependency-type: direct:production
    update-type: version-update:semver-minor
    dependency-group: gh-actions-releases
  ...
  
  Signed-off-by: dependabot[bot] <support@github.com>
  Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

- **chore: pre-commit-config update (#324)**
  

- **fix: disable pre-commit.ci autoupdate (#326)**
  It includes undesired updates to alpha releases and broken releases like markdownlint

- **chore(release): reliabot v0.3.2**
  