### PR TITLE
chore: better dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     package-ecosystem: pip
     schedule:
       interval: monthly
+    groups:
+      python-tools:
+        - ruff
+        - tox
   - directory: /
     package-ecosystem: github-actions
     schedule:
@@ -17,7 +21,7 @@ updates:
       gh-actions-infrastructure:
         patterns:
           - actions/*
-          - github/codeql-action/*
+          - github/*
           - ossf/*
           - step-security/*
       gh-actions-releases:


### PR DESCRIPTION
Include github/codeql-action in gh-actions-infrastructure group
Create python-tools group for ruff and tox