### PR TITLE
chore: use python3.13 for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,8 +81,7 @@ repos:
         args: [--update]
         entry: reliabot/reliabot.py
         language: python
-        # Can't use 3.13 yet - https://github.com/dupuy/reliabot/issues/174
-        language_version: python3.12
+        language_version: python3.13
         name: maintain dependabot configuration
         pass_filenames: false
       - id: reliabot-pre-commit-files
@@ -93,8 +92,7 @@ repos:
         entry: reliabot/reliabot.py
         files: ^(reliabot/reliabot[.]py|[.]pre-commit-(config|hooks)[.]py)$
         language: python
-        # Can't use 3.13 yet - https://github.com/dupuy/reliabot/issues/174
-        language_version: python3.12
+        language_version: python3.13
         name: maintain pre-commit files configuration
         pass_filenames: false
 
@@ -178,7 +176,7 @@ repos:
 
   # Python
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.10
+    rev: v0.15.12
     hooks:
       # Run the linter.
       - id: ruff
@@ -225,7 +223,7 @@ repos:
         args: [-c, pyproject.toml]
         additional_dependencies: ['bandit[toml]']
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.20.1
+    rev: v1.20.2
     hooks:
       - id: mypy
   - repo: https://github.com/pre-commit/pygrep-hooks
@@ -246,7 +244,7 @@ repos:
     hooks:
       - id: dead
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.10
+    rev: v0.15.12
     hooks:
       # Run the formatter.
       - id: ruff-format


### PR DESCRIPTION
Update reliabot maintenance pre-commit to use Python 3.13.
Also include version bumps from `pre-commit-update`