### PR TITLE
fix: fork PRs assign-labels w/pull_request_target

### DIFF
--- a/.github/workflows/assign-labels.yaml
+++ b/.github/workflows/assign-labels.yaml
@@ -10,7 +10,7 @@
 name: 'Assign labels to PRs from conventional commit titles'
 
 on:
-  pull_request:
+  pull_request_target:
     branches: ['main']
     types:
       - opened
@@ -39,8 +39,7 @@ jobs:
       - name: 'Assign labels'
         uses: dupuy/action-assign-labels@671a4ca2da0f900464c58b8b5540a1e07133e915 # v1.5.1
         with:
-          # Partial fix for #192, workflows in forked repos can't edit labels
-          apply-changes: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          apply-changes: true
           conventional-commits: |
             conventional-commits:
               - type: 'fix'


### PR DESCRIPTION
Enable assign-labels to actually work for fork PRs.