### PR TITLE
fix: remove unsafe pull_request_target workflow

### DIFF
--- a/.github/workflows/codacy-coverage-reporter.yaml
+++ b/.github/workflows/codacy-coverage-reporter.yaml
@@ -2,8 +2,10 @@
 
 name: 'Codacy Coverage Reporter'
 on:
-  - pull_request_target
-  - push
+  workflow_run:
+    workflows: ['Run tests with coverage']
+    types:
+      - completed
 
 # Declare default permissions as read only.
 permissions:
@@ -13,8 +15,13 @@ jobs:
   codacy-coverage-reporter:
     runs-on: ubuntu-24.04
     name: codacy-coverage-reporter
+    permissions:
+      contents: read
+      actions: read # Needed to download artifacts
     # Only run on primary fork, since this requires a Codacy project token
-    if: github.repository == 'dupuy/reliabot'
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.repository == 'dupuy/reliabot'
     steps:
       - name: 'Harden runner'
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
@@ -24,31 +31,21 @@ jobs:
           allowed-endpoints: >
             api.codacy.com:443
             artifacts.codacy.com:443
-            files.pythonhosted.org:443
             github.com:443
-            pypi.org:443
-            raw.githubusercontent.com:443
-            release-assets.githubusercontent.com:443
+            objects.githubusercontent.com:443
 
       - name: 'Checkout repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_sha }}
           persist-credentials: false
 
-      - name: 'Install Poetry'
-        run: 'pipx install poetry'
-
-      - name: 'Set up Python'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: '3.12'
-          cache: 'poetry'
-
-      - name: 'Install dependencies with extras'
-        run: 'poetry install --extras re2 --with testing'
-
-      - name: 'Run tests with coverage'
-        run: 'poetry run tox -e py'
+      - name: 'Download coverage report'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh run download ${{ github.event.workflow_run.id }} --name coverage-report
 
       - name: 'Run codacy-coverage-reporter'
         uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699 # v1.3.0

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,6 +18,9 @@ permissions:
 jobs:
   prepare:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      actions: read # Needed to download artifacts
     # Security: only run if the triggering workflow succeeded and it was a push.
     if: >
       github.event.workflow_run.event == 'push' &&
@@ -34,7 +37,7 @@ jobs:
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           disable-sudo: true
-          egress-policy: audit
+          egress-policy: block
           allowed-endpoints: >
             api.github.com:443
             github.com:443
@@ -75,13 +78,15 @@ jobs:
     permissions:
       id-token: write # Trusted publishing requires this permission
       attestations: write
+      contents: read
+      actions: read # Needed to download artifacts
 
     steps:
       - name: 'Harden runner'
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           disable-sudo: true
-          egress-policy: audit
+          egress-policy: block
           allowed-endpoints: >
             actions.githubusercontent.com:443
             api.github.com:443
@@ -187,13 +192,14 @@ jobs:
       id-token: write # Trusted publishing requires this permission
       attestations: write
       contents: write # Needed for annotated tag push
+      actions: read # Needed to download artifacts
 
     steps:
       - name: 'Harden runner'
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           disable-sudo: true
-          egress-policy: audit
+          egress-policy: block
           allowed-endpoints: >
             actions.githubusercontent.com:443
             api.github.com:443

--- a/.github/workflows/python-app.yaml
+++ b/.github/workflows/python-app.yaml
@@ -99,7 +99,6 @@ jobs:
         python-version:
           - '3.10'
           - '3.11'
-          - '3.12'
           - '3.13'
           - '3.14'
 
@@ -111,8 +110,10 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             *.stepsecurity.io:443
+            api.github.com:443
             files.pythonhosted.org:443
             github.com:443
+            objects.githubusercontent.com:443
             pypi.org:443
 
       - name: 'Checkout repository'
@@ -214,7 +215,7 @@ jobs:
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           disable-sudo: true
-          egress-policy: audit
+          egress-policy: block
           allowed-endpoints: >
             api.github.com:443
             files.pythonhosted.org:443

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,0 +1,85 @@
+name: 'Run tests with coverage'
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
+
+# Declare default permissions as read only.
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: 'Harden runner'
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            *.stepsecurity.io:443
+            api.github.com:443
+            files.pythonhosted.org:443
+            github.com:443
+            objects.githubusercontent.com:443
+            pypi.org:443
+
+      - name: 'Checkout repository'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # The `git describe` COMMIT_TAG output requires these fetch-* options.
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: 'Install Poetry'
+        run: 'pipx install poetry'
+
+      - name: 'Compute outputs'
+        id: computed
+        run: >
+          {
+            COMMIT_TAG=$(git describe) &&
+              echo "COMMIT_TAG=$COMMIT_TAG" >&2 ;
+            VERSION_TAG="v`poetry version --short |
+              sed -e 's/a/-alpha./' -e 's/b/-beta./' -e 's/rc/-rc./'`" &&
+                echo "VERSION_TAG=$VERSION_TAG" ;
+            if [ "$COMMIT_TAG" = "$VERSION_TAG" ]; then
+              echo "pr-commit=false" ;
+            else
+              echo "pr-commit=true" ;
+            fi
+          } | tee -a "$GITHUB_OUTPUT"
+
+      - name: 'Set up Python'
+        if: steps.computed.outputs.pr-commit == 'true'
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+          cache: 'poetry'
+
+      - name: 'Install dependencies with extras'
+        if: steps.computed.outputs.pr-commit == 'true'
+        run: 'poetry install --extras re2 --with testing'
+
+      - name: 'Run tests with coverage'
+        if: steps.computed.outputs.pr-commit == 'true'
+        run: 'poetry run tox -e py'
+
+      - name: 'Upload coverage report'
+        if: steps.computed.outputs.pr-commit == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          if-no-files-found: error
+          name: coverage-report
+          path: cobertura.xml
+          retention-days: 1


### PR DESCRIPTION
Addresses #360 for the Codacy coverage upload case.
For the assign-labels action, no code is built, tested, or executed, so pull_request_target is safe.