### PR TITLE
fix: remove unneeded checkout for codacy report

### DIFF
--- a/.github/workflows/codacy-coverage-reporter.yaml
+++ b/.github/workflows/codacy-coverage-reporter.yaml
@@ -34,13 +34,6 @@ jobs:
             github.com:443
             objects.githubusercontent.com:443
 
-      - name: 'Checkout repository'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: ${{ github.event.workflow_run.head_repository.full_name }}
-          ref: ${{ github.event.workflow_run.head_sha }}
-          persist-credentials: false
-
       - name: 'Download coverage report'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codacy-coverage-reporter.yaml
+++ b/.github/workflows/codacy-coverage-reporter.yaml
@@ -30,6 +30,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.codacy.com:443
+            api.github.com:443
             artifacts.codacy.com:443
             github.com:443
             objects.githubusercontent.com:443

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -46,6 +46,7 @@ jobs:
       - name: 'Download artifacts'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           gh run download ${{ github.event.workflow_run.id }} --dir artifacts
 


### PR DESCRIPTION
This caused a CRITICAL security alert for Dangerous-Workflow
See https://github.com/dupuy/reliabot/security/code-scanning/22 and Issue #360.