### PR TITLE
fix: add GH_REPO for all workflow_run jobs

### DIFF
--- a/.github/workflows/codacy-coverage-reporter.yaml
+++ b/.github/workflows/codacy-coverage-reporter.yaml
@@ -38,6 +38,7 @@ jobs:
       - name: 'Download coverage report'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           gh run download ${{ github.event.workflow_run.id }} --name coverage-report
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -105,6 +105,7 @@ jobs:
       - name: 'Download artifacts'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           gh run download ${{ github.event.workflow_run.id }} --dir artifacts
 
@@ -223,6 +224,7 @@ jobs:
       - name: 'Download artifacts'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           gh run download ${{ github.event.workflow_run.id }} --dir artifacts
 


### PR DESCRIPTION
Any use of `gh run` in a workflow_run job needs GH_REPO env.