### PR TITLE
fix: dependency-review failures

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -14,6 +14,10 @@ on: [pull_request]
 permissions:
   contents: read
 
+concurrency:
+  group: dependency-review-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dependency-review:
     runs-on: ubuntu-24.04
@@ -24,6 +28,7 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
+            api.deps.dev:443
             api.github.com:443
             github.com:443
 


### PR DESCRIPTION
GitHub Copilot recommended these changes:

The job is failing due to two issues:

### 1. Cache Conflict (Primary Issue)

The harden-runner step is failing with:

```Code
Failed to save: Unable to reserve cache with key harden-runner-cacheKey, another job may be creating this cache.
```
This occurs when multiple jobs run concurrently and attempt to save to the same cache key. Since your workflow is triggered on `pull_request` events, concurrent runs can cause cache collisions.

**Solution**: Add concurrency control to the workflow to prevent simultaneous runs:

```YAML
name: 'Dependency review'
on: [pull_request]

concurrency:
  group: dependency-review-${{ github.ref }}
  cancel-in-progress: true

permissions:
  contents: read

jobs:
  dependency-review:
    runs-on: ubuntu-24.04
    steps:
      - name: 'Harden runner'
        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
        with:
          disable-sudo: true
          egress-policy: block
          allowed-endpoints: >
            api.github.com:443
            github.com:443

      - name: 'Checkout repository'
        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
        with:
          persist-credentials: false

      - name: 'Dependency review'
        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
```

### 2. Secondary Issue: Dependency Review Fetch Failure

The dependency-review-action failed with `fetch failed`, likely due to the `egress-policy: block` combined with incomplete allowed endpoints. You may need to add additional endpoints if the dependency review action requires them. However, the cache conflict is the primary blocker.
